### PR TITLE
修复事件调度中使用阻塞API导致卡死

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -20,7 +20,7 @@
 import love.forte.gradle.common.core.project.ProjectDetail
 import love.forte.gradle.common.core.project.Version
 import love.forte.gradle.common.core.project.minus
-import love.forte.gradle.common.core.project.version
+import love.forte.gradle.common.core.project.version as v
 
 /*
 *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
@@ -40,7 +40,7 @@ import love.forte.gradle.common.core.project.version
 */
 
 // 3.0.0-M1
-val simbotVersion = version(3, 0, 0) - version("M1")
+val simbotVersion = v(3, 0, 0) - v("M2")
 
 val simbotApi = "love.forte.simbot:simbot-api:$simbotVersion"
 val simbotCore = "love.forte.simbot:simbot-core:$simbotVersion"
@@ -51,12 +51,12 @@ object P : ProjectDetail() {
     const val DESCRIPTION = "Simple Robot框架下针对开黑啦(Kook)平台的组件实现"
     const val HOMEPAGE = "https://github.com/simple-robot/simbot-component-kook"
     
-    private val baseVersion = version(
+    private val baseVersion = v(
         "${simbotVersion.major}.${simbotVersion.minor}",
         0, 0
     )
     
-    private val alphaSuffix = version("alpha", 2)
+    private val alphaSuffix = v("alpha", 2)
     
     override val version: Version = baseVersion - alphaSuffix
     

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -39,7 +39,6 @@ import love.forte.gradle.common.core.project.version as v
 *
 */
 
-// 3.0.0-M1
 val simbotVersion = v(3, 0, 0) - v("M2")
 
 val simbotApi = "love.forte.simbot:simbot-api:$simbotVersion"

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -18,6 +18,7 @@
 @file:Suppress("MemberVisibilityCanBePrivate", "unused")
 
 import love.forte.gradle.common.core.project.ProjectDetail
+import love.forte.gradle.common.core.project.Version
 import love.forte.gradle.common.core.project.minus
 import love.forte.gradle.common.core.project.version
 
@@ -50,13 +51,17 @@ object P : ProjectDetail() {
     const val DESCRIPTION = "Simple Robot框架下针对开黑啦(Kook)平台的组件实现"
     const val HOMEPAGE = "https://github.com/simple-robot/simbot-component-kook"
     
-    override val version: love.forte.gradle.common.core.project.Version = version(
+    private val baseVersion = version(
         "${simbotVersion.major}.${simbotVersion.minor}",
         0, 0
-    ) - version("alpha", 2)
+    )
     
-    val snapshotVersion: love.forte.gradle.common.core.project.Version =
-        version - love.forte.gradle.common.core.project.Version.SNAPSHOT
+    private val alphaSuffix = version("alpha", 2)
+    
+    override val version: Version = baseVersion - alphaSuffix
+    
+    val snapshotVersion: Version =
+        baseVersion - (alphaSuffix - Version.SNAPSHOT)
     
     override val group: String get() = GROUP
     override val description: String get() = DESCRIPTION

--- a/buildSrc/src/main/kotlin/R.kt
+++ b/buildSrc/src/main/kotlin/R.kt
@@ -14,8 +14,8 @@ private val sonatypeUserInfo by lazy {
     userInfo
 }
 
-private val sonatypeUsername: String? get() = sonatypeUserInfo?.username
-private val sonatypePassword: String? get() = sonatypeUserInfo?.password
+val sonatypeUsername: String? get() = sonatypeUserInfo?.username
+val sonatypePassword: String? get() = sonatypeUserInfo?.password
 
 val ReleaseRepository by lazy {
     Repositories.Central.Default.copy(SimpleCredentials(sonatypeUsername, sonatypePassword))

--- a/buildSrc/src/main/kotlin/simbot-kook-maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot-kook-maven-publish.gradle.kts
@@ -69,7 +69,7 @@ checkPublishConfigurable {
         isSnapshot = isSnapshot()
         releasesRepository = ReleaseRepository
         snapshotRepository = SnapshotRepository
-        gpg = Gpg.ofSystemPropOrNull()
+        gpg = if (isSnapshot()) null else Gpg.ofSystemPropOrNull()
     }
     
     if (isSnapshot()) {

--- a/buildSrc/src/main/kotlin/simbot-kook-maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot-kook-maven-publish.gradle.kts
@@ -17,6 +17,7 @@
 
 import love.forte.gradle.common.core.Gpg
 import love.forte.gradle.common.core.property.systemProp
+import love.forte.gradle.common.publication.configure.commonConfigMavenPublication
 import love.forte.gradle.common.publication.configure.jvmConfigPublishing
 import util.checkPublishConfigurable
 
@@ -50,8 +51,6 @@ println("isReleaseOnly: $isReleaseOnly")
 println("isPublishConfigurable: $isPublishConfigurable")
 
 checkPublishConfigurable {
-    val p = project
-    
     jvmConfigPublishing {
         project = P
         publicationName = "kookDist"
@@ -73,132 +72,33 @@ checkPublishConfigurable {
         gpg = Gpg.ofSystemPropOrNull()
     }
     
-    show()
+    if (isSnapshot()) {
+        publishing {
+            publications.withType<MavenPublication> {
+                version = P.snapshotVersion.toString()
+            }
+        }
+    }
+    
+    publishing {
+        publications.withType<MavenPublication> {
+            show()
+        }
+    }
+    
+    
 }
 
-// if (isPublishConfigurable) {
-//     val sonatypeUsername: String? = systemProp("OSSRH_USER")
-//     val sonatypePassword: String? = systemProp("OSSRH_PASSWORD")
-//
-//     if (sonatypeUsername == null || sonatypePassword == null) {
-//         println("[WARN] - sonatype.username or sonatype.password is null, cannot config nexus publishing.")
-//     }
-//
-//     val jarSources by tasks.registering(Jar::class) {
-//         archiveClassifier.set("sources")
-//         from(sourceSets["main"].allSource)
-//     }
-//
-//     val jarJavadoc by tasks.registering(Jar::class) {
-//         archiveClassifier.set("javadoc")
-//     }
-//
-//     publishing {
-//         publications {
-//             create<MavenPublication>("kookDist") {
-//                 from(components["java"])
-//                 artifact(jarSources)
-//                 artifact(jarJavadoc)
-//
-//                 groupId = project.group.toString()
-//                 artifactId = project.name
-//                 version = project.version.toString()
-//                 description = project.description?.toString() ?:P.DESCRIPTION
-//
-//                 pom {
-//                     show()
-//
-//                     name.set("${project.group}:${project.name}")
-//                     description.set("Simple Robot框架下针对开黑啦(Kook)平台的组件实现")
-//                     url.set("https://github.com/simple-robot/simbot-component-kook")
-//                     licenses {
-//                         license {
-//                             name.set("GNU GENERAL PUBLIC LICENSE, Version 3")
-//                             url.set("https://www.gnu.org/licenses/gpl-3.0-standalone.html")
-//                         }
-//                         license {
-//                             name.set("GNU LESSER GENERAL PUBLIC LICENSE, Version 3")
-//                             url.set("https://www.gnu.org/licenses/lgpl-3.0-standalone.html")
-//                         }
-//                     }
-//                     scm {
-//                         url.set("https://github.com/simple-robot/simbot-component-kook")
-//                         connection.set("scm:git:https://github.com/simple-robot/simbot-component-kook.git")
-//                         developerConnection.set("scm:git:ssh://git@github.com/simple-robot/simbot-component-kook.git")
-//                     }
-//
-//                     setupDevelopers()
-//                 }
-//             }
-//
-//
-//
-//             repositories {
-//                 configMaven(Sonatype.Central, sonatypeUsername, sonatypePassword)
-//                 configMaven(Sonatype.Snapshot, sonatypeUsername, sonatypePassword)
-//             }
-//         }
-//     }
-//
-//     signing {
-//         val keyId = System.getenv("GPG_KEY_ID")
-//         val secretKey = System.getenv("GPG_SECRET_KEY")
-//         val password = System.getenv("GPG_PASSWORD")
-//
-//         setRequired {
-//             !project.version.toString().endsWith("SNAPSHOT")
-//         }
-//
-//         useInMemoryPgpKeys(keyId, secretKey, password)
-//
-//         sign(publishing.publications["kookDist"])
-//     }
-//
-//
-//     println("[publishing-configure] - [$name] configured.")
-// }
 
-
-// fun RepositoryHandler.configMaven(sonatype: Sonatype, username: String?, password: String?) {
-//     maven {
-//         name = sonatype.name
-//         url = uri(sonatype.url)
-//         credentials {
-//             this.username = username
-//             this.password = password
-//         }
-//     }
-// }
-
-
-// /**
-//  * 配置开发者/协作者信息。
-//  *
-//  */
-// fun MavenPom.setupDevelopers() {
-//     developers {
-//         developer {
-//             id.set("forte")
-//             name.set("ForteScarlet")
-//             email.set("ForteScarlet@163.com")
-//             url.set("https://github.com/ForteScarlet")
-//         }
-//         developer {
-//             id.set("forliy")
-//             name.set("ForliyScarlet")
-//             email.set("ForliyScarlet@163.com")
-//             url.set("https://github.com/ForliyScarlet")
-//         }
-//     }
-// }
-
-fun show() {
+fun MavenPublication.show() {
     //// show project info
     println("========================================================")
-    println("== project.group:       $group")
-    println("== project.name:        $name")
-    println("== project.version:     $version")
-    println("== project.description: $description")
+    println("== MavenPublication for ${project.name}")
+    println("== maven.pub.group:       $group")
+    println("== maven.pub.name:        $name")
+    println("== project.verson:        ${project.version}")
+    println("== maven.pub.version:     $version")
+    println("== maven.pub.description: $description")
     println("========================================================")
 }
 

--- a/buildSrc/src/main/kotlin/simbot-kook-module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot-kook-module-conventions.gradle.kts
@@ -44,6 +44,9 @@ plugins {
 }
 
 setup(P)
+if (isSnapshot()) {
+    version = P.snapshotVersion.toString()
+}
 
 repositories {
     mavenLocal()

--- a/buildSrc/src/main/kotlin/simbot-kook-nexus-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot-kook-nexus-publish.gradle.kts
@@ -17,6 +17,8 @@
 
 import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.core.property.systemProp
+import love.forte.gradle.common.core.repository.Repositories
+import love.forte.gradle.common.core.repository.Repository
 import util.checkPublishConfigurable
 import java.time.Duration
 
@@ -42,6 +44,9 @@ plugins {
 }
 
 setup(P)
+if (isSnapshot()) {
+    version = P.snapshotVersion.toString()
+}
 
 val (isSnapshotOnly, isReleaseOnly, isPublishConfigurable) = checkPublishConfigurable()
 
@@ -51,8 +56,8 @@ logger.info("isPublishConfigurable: {}", isPublishConfigurable)
 
 
 if (isPublishConfigurable) {
-    val sonatypeUsername: String? = systemProp("OSSRH_USER")
-    val sonatypePassword: String? = systemProp("OSSRH_PASSWORD")
+    val sonatypeUsername: String? = sonatypeUsername
+    val sonatypePassword: String? = sonatypePassword
     
     if (sonatypeUsername == null || sonatypePassword == null) {
         println("[WARN] - sonatype.username or sonatype.password is null, cannot config nexus publishing.")
@@ -72,7 +77,7 @@ if (isPublishConfigurable) {
         
         repositories {
             sonatype {
-                snapshotRepositoryUrl.set(uri(Sonatype.Snapshot.URL))
+                snapshotRepositoryUrl.set(uri(Repositories.Snapshot.URL))
                 username.set(sonatypeUsername)
                 password.set(sonatypePassword)
             }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -5,7 +5,7 @@ spring-boot = "2.7.0"
 openjdk-jmh = "1.35"
 forte-di = "0.0.3"
 forte-annotationTool = "0.6.3"
-ktor = "2.0.0"
+ktor = "2.1.3"
 
 [libraries]
 # jetbrains-annotation

--- a/simbot-component-kook-api/build.gradle.kts
+++ b/simbot-component-kook-api/build.gradle.kts
@@ -19,6 +19,7 @@
 plugins {
     `simbot-kook-module-conventions`
     `simbot-kook-maven-publish`
+    `simbot-kook-suspend-transform`
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
@@ -156,9 +156,9 @@ public abstract class KookApiRequest<T> {
      *
      * 可以通过重写 [requestFinishingAction] 来实现提供额外的收尾操作，例如为请求提供 body 等。
      *
-     * @param postchecker 当得到了 http response 之后的后置检查，可以用于提供部分自定义的响应值检查函数，例如进行速率限制检查。
+     * @param postChecker 当得到了 http response 之后的后置检查，可以用于提供部分自定义的响应值检查函数，例如进行速率限制检查。
      *
-     * @throws ApiRateLimitException 当API速度达到上限的时候。检查需要通过 [postchecker] 进行实现支持。
+     * @throws ApiRateLimitException 当API速度达到上限的时候。检查需要通过 [postChecker] 进行实现支持。
      *
      * @see request
      */
@@ -168,10 +168,10 @@ public abstract class KookApiRequest<T> {
         client: HttpClient,
         authorization: String,
         decoder: Json = DEFAULT_JSON,
-        postchecker: Consumer<HttpResponse> = defaultRequestPostChecker
+        postChecker: Consumer<HttpResponse> = defaultRequestPostChecker
     ): ApiResult = runInBlocking {
         request(client, authorization, decoder) { resp ->
-            runWithInterruptible { postchecker.accept(resp) }
+            runWithInterruptible { postChecker.accept(resp) }
         }
     }
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
@@ -34,10 +34,12 @@ import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_GLOBAL
 import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_LIMIT
 import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_REMAINING
 import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_RESET
+import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.utils.runInBlocking
 import love.forte.simbot.utils.runWithInterruptible
 import java.util.function.Consumer
 
+private val logger = LoggerFactory.getLogger("KookApiRequest.debug")
 
 /**
  * 代表、包装了一个 Kook api的请求。
@@ -111,12 +113,15 @@ public abstract class KookApiRequest<T> {
         }
 
         postChecker(response)
-
+    
+        logger.trace("api request response.body(), response: {}", response)
+        
         val result: ApiResult = response.body()
-
+    
+        logger.trace("api request result pre rate limit: {}", result)
+        
         // init rate limit info.
         val headers = response.headers
-
 
         val limit = headers[X_RATE_LIMIT_LIMIT]?.toLongOrNull() // ?: RateLimit.DEFAULT.limit
         val remaining = headers[X_RATE_LIMIT_REMAINING]?.toLongOrNull() // ?: RateLimit.DEFAULT.remaining
@@ -137,6 +142,9 @@ public abstract class KookApiRequest<T> {
         }
 
         result.rateLimit = rateLimit
+    
+        logger.trace("api request result: {}", result)
+    
         return result
     }
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiResult.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiResult.kt
@@ -147,7 +147,7 @@ public class ApiResult @ApiResultType constructor(
 ) {
 
     /**
-     * 当前api响应值的 [速率限制][RateLimit] 信息。会在当前类实例化之后在进行初始化。
+     * 当前api响应值的 [速率限制][RateLimit] 信息。会在当前类实例化之后再进行初始化。
      */
     @Transient
     public var rateLimit: RateLimit = RateLimit.DEFAULT

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/Signal.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/Signal.kt
@@ -177,13 +177,15 @@ public sealed class Signal<T> {
      */
     @Serializable
     public data class Ping(public val sn: Long) : Signal<Unit>() {
-        override val s: Int get() = S_CODE
+        override val s: Int = S_CODE
         override val d: Unit get() = Unit
+        
+        public fun jsonValue(): String = """{"s":$S_CODE,"sn":$sn}"""
 
         public companion object : JsonValueFactory<Ping> {
             public const val S_CODE: Int = 2
             @JvmStatic
-            override fun jsonValue(value: Ping): String = """{"s":$S_CODE,"sn":${value.sn}}"""
+            override fun jsonValue(value: Ping): String = value.jsonValue()
 
         }
     }
@@ -209,6 +211,9 @@ public sealed class Signal<T> {
         override val s: Int get() = S_CODE
         override val d: Unit get() = Unit
         public const val S_CODE : Int = 3
+        override fun toString(): String {
+            return "Signal.Pong(s=$S_CODE)"
+        }
     }
     //endregion
 

--- a/simbot-component-kook-boot/build.gradle.kts
+++ b/simbot-component-kook-boot/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     
     
     testImplementation(libs.spring.boot.test)
+    testImplementation(libs.spring.boot.webflux)
     testImplementation("love.forte.simbot:simbot-logger:$simbotVersion")
     testImplementation("love.forte.simbot.boot:simboot-core-spring-boot-starter:$simbotVersion")
     testImplementation(libs.ktor.client.cio)

--- a/simbot-component-kook-boot/build.gradle.kts
+++ b/simbot-component-kook-boot/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     
     
     testImplementation(libs.spring.boot.test)
+    testImplementation("love.forte.simbot:simbot-logger:$simbotVersion")
     testImplementation("love.forte.simbot.boot:simboot-core-spring-boot-starter:$simbotVersion")
     testImplementation(libs.ktor.client.cio)
 }

--- a/simbot-component-kook-boot/src/test/kotlin/forte/example/spring/app/SpringAppMain.kt
+++ b/simbot-component-kook-boot/src/test/kotlin/forte/example/spring/app/SpringAppMain.kt
@@ -27,6 +27,7 @@ open class TestListener {
     suspend fun KookContactMessageEvent.onMsg() {
         println(messageContent)
         user().send(messageContent)
+        reply(messageContent)
     }
 
 }

--- a/simbot-component-kook-boot/src/test/resources/application.yml
+++ b/simbot-component-kook-boot/src/test/resources/application.yml
@@ -1,8 +1,10 @@
 logging:
   level:
-    love.forte.simboot: debug
-    love.forte.simbot: debug
-    forte.example: debug
+    love.forte.simbot.kook.bot.client: TRACE
+    love.forte.simboot: trace
+    love.forte.simbot: trace
+    forte.example: trace
+    forliy.bot: debug
 
 simbot:
   bot-configuration-resources:

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookBotManager.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookBotManager.kt
@@ -233,7 +233,6 @@ public class KookBotManagerAutoRegistrarFactory :
  * 配置并构建一个 [KookBotManager] 实例。
  *
  */
-@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("Use Factory in application")
 public fun kookBotManager(
     eventProcessor: EventProcessor,

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookContact.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookContact.kt
@@ -30,40 +30,37 @@ import love.forte.simbot.kook.objects.User as KkUser
  * @author ForteScarlet
  */
 public interface KookContact : Contact {
-
+    
     /**
      * id。
      */
     override val id: ID get() = sourceUser.id
-
+    
     /**
      * 用户名。
      */
     override val username: String get() = sourceUser.username
-
+    
     /**
      * Kook 的源用户信息。
      */
     public val sourceUser: KkUser
-
+    
     /**
      * 联系人所属bot。
      */
     override val bot: KookComponentBot
-
+    
+    /**
+     * 头像。
+     */
+    override val avatar: String get() = sourceUser.avatar
+    
     /**
      * 发送消息。
      */
     @JvmSynthetic
     override suspend fun send(message: Message): MessageReceipt
-
-
-    /**
-     * 头像。
-     */
-    override val avatar: String get() = sourceUser.avatar
-
-
-
-
+    
+    
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookGuild.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookGuild.kt
@@ -17,13 +17,12 @@
 
 package love.forte.simbot.component.kook
 
-import love.forte.simbot.Api4J
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
 import love.forte.simbot.ID
-import love.forte.simbot.JavaDuration
 import love.forte.simbot.definition.*
 import love.forte.simbot.utils.item.Items
 import love.forte.simbot.utils.item.Items.Companion.emptyItems
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import love.forte.simbot.kook.objects.Guild as KkGuild
 
@@ -56,10 +55,11 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
     // region owner api
     override val ownerId: ID
     
-    @OptIn(Api4J::class)
-    override val owner: KookGuildMember
-    
-    @JvmSynthetic
+    /**
+     * 频道服务器的创建人。
+     */
+    @JvmBlocking(asProperty = true, suffix = "")
+    @JvmAsync(asProperty = true)
     override suspend fun owner(): KookGuildMember
     // endregion
     
@@ -67,14 +67,9 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
     /**
      * 根据指定ID查询对应用户信息，或得到null。
      */
-    @OptIn(Api4J::class)
-    override fun getMember(id: ID): KookGuildMember?
-    
-    /**
-     * 根据指定ID查询对应用户信息，或得到null。
-     */
-    @JvmSynthetic
-    override suspend fun member(id: ID): KookGuildMember? = getMember(id)
+    @JvmBlocking(baseName = "getMember", suffix = "")
+    @JvmAsync(baseName = "getMember")
+    override suspend fun member(id: ID): KookGuildMember?
     
     /**
      * 直接获取用户列表的副本。
@@ -109,16 +104,9 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
      *
      * 未找到时得到null。
      */
-    @OptIn(Api4J::class)
-    override fun getChannel(id: ID): KookChannel?
-    
-    /**
-     * 尝试根据指定ID获取匹配的[子频道][KookChannel]。
-     *
-     * 未找到时得到null。
-     */
-    @JvmSynthetic
-    override suspend fun channel(id: ID): KookChannel? = getChannel(id)
+    @JvmBlocking(baseName = "getChannel", suffix = "")
+    @JvmAsync(baseName = "getChannel")
+    override suspend fun channel(id: ID): KookChannel?
     
     /**
      * 获取当前频道服务器下的子频道序列。
@@ -135,22 +123,15 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
      *
      * 未找到时得到null。
      */
-    @JvmSynthetic
+    @JvmBlocking(baseName = "getChild", suffix = "")
+    @JvmAsync(baseName = "getChild")
     override suspend fun child(id: ID): KookChannel? = channel(id)
-    
-    /**
-     * 尝试根据指定ID获取匹配的[子频道][KookChannel]。
-     *
-     * 未找到时得到null。
-     */
-    @OptIn(Api4J::class)
-    override fun getChild(id: ID): KookChannel? = getChannel(id)
     
     /**
      * 得到当前频道下所有的分组型频道。
      */
     public val categories: List<KookChannelCategory>
-   
+    
     
     /**
      * 尝试根据ID获取匹配的分类对象。
@@ -164,8 +145,7 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
      * Deprecated: 尚未支持
      */
     @Deprecated(
-        "Not support yet.",
-        ReplaceWith("emptyItems()", "love.forte.simbot.utils.item.Items.Companion.emptyItems")
+        "Not support yet.", ReplaceWith("emptyItems()", "love.forte.simbot.utils.item.Items.Companion.emptyItems")
     )
     override val roles: Items<Role>
         get() = emptyItems()
@@ -177,38 +157,15 @@ public interface KookGuild : Guild, KookComponentDefinition<KkGuild> {
     @Deprecated("Guild mute is not supported", ReplaceWith("false"))
     override suspend fun mute(duration: Duration): Boolean = false
     
-    @OptIn(Api4J::class)
-    @Deprecated("Guild mute is not supported", ReplaceWith("false"))
-    override fun muteBlocking(time: Long, timeUnit: TimeUnit): Boolean = false
-    
     @Deprecated("Guild mute is not supported", ReplaceWith("false"))
     override suspend fun unmute(): Boolean = false
-    
-    @OptIn(Api4J::class)
-    @Deprecated("Guild mute is not supported", ReplaceWith("false"))
-    override fun unmuteBlocking(): Boolean = false
-    
-    @OptIn(Api4J::class)
-    @Deprecated("Guild mute is not supported", ReplaceWith("false"))
-    override fun muteBlocking(): Boolean = false
-    
-    @OptIn(Api4J::class)
-    @Deprecated("Guild mute is not supported", ReplaceWith("false"))
-    override fun muteBlocking(duration: JavaDuration): Boolean = false
-    
     // endregion
     
     
     /**
      * 频道服务器没有上层。
      */
-    @JvmSynthetic
+    @JvmBlocking(asProperty = true, suffix = "")
+    @JvmAsync(asProperty = true)
     override suspend fun previous(): Organization? = null
-    
-    /**
-     * 频道服务器没有上层。
-     */
-    @OptIn(Api4J::class)
-    override val previous: Organization?
-        get() = null
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookUserChat.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookUserChat.kt
@@ -17,7 +17,8 @@
 
 package love.forte.simbot.component.kook
 
-import love.forte.simbot.Api4J
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
 import love.forte.simbot.ID
 import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.component.kook.message.KookMessageCreatedReceipt
@@ -28,7 +29,6 @@ import love.forte.simbot.kook.api.userchat.UserChatDeleteRequest
 import love.forte.simbot.kook.api.userchat.UserChatView
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
-import love.forte.simbot.utils.runInBlocking
 
 /**
  * Kook 的 [user-chat 私聊会话](https://developer.kaiheila.cn/doc/http/user-chat)。
@@ -56,45 +56,25 @@ public interface KookUserChat : Stranger, Contact, KookComponentDefinition<UserC
     /**
      * 向当前好友（私聊会话）发送消息。
      */
-    @JvmSynthetic
+    @JvmBlocking
+    @JvmAsync
     override suspend fun send(message: Message): KookMessageReceipt
     
     /**
      * 向当前好友（私聊会话）发送消息。
      */
-    @JvmSynthetic
+    @JvmBlocking
+    @JvmAsync
     override suspend fun send(text: String): KookMessageCreatedReceipt
     
     /**
      * 向当前好友（私聊会话）发送消息。
      */
-    @JvmSynthetic
+    @JvmBlocking
+    @JvmAsync
     override suspend fun send(message: MessageContent): KookMessageReceipt
     
-    /**
-     * 向当前好友（私聊会话）发送消息。
-     */
-    @Api4J
-    override fun sendBlocking(text: String): KookMessageCreatedReceipt = runInBlocking {
-        send(text)
-    }
-    
-    /**
-     * 向当前好友（私聊会话）发送消息。
-     */
-    @Api4J
-    override fun sendBlocking(message: Message): KookMessageReceipt = runInBlocking {
-        send(message)
-    }
-    
-    /**
-     * 向当前好友（私聊会话）发送消息。
-     */
-    @Api4J
-    override fun sendBlocking(message: MessageContent): KookMessageReceipt = runInBlocking {
-        send(message)
-    }
-    
+    // TODO Doc update.
     /**
      * 删除当前 [聊天会话][KookUserChat].
      *
@@ -102,17 +82,6 @@ public interface KookUserChat : Stranger, Contact, KookComponentDefinition<UserC
      * 在删除的过程中会直接抛出请求 [UserChatDeleteRequest] 过程中可能产生的任何异常。
      *
      */
+    @JvmSynthetic
     override suspend fun delete(): Boolean
-    
-    /**
-     * 阻塞地删除当前 [聊天会话][KookUserChat].
-     *
-     * 通过 [UserChatDeleteRequest] 删除当前聊天会话。
-     *
-     */
-    @Api4J
-    override fun deleteBlocking(): Boolean {
-        return runInBlocking { delete() }
-    }
-    
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.component.kook.internal
 
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import love.forte.simbot.DiscreetSimbotApi
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
@@ -315,7 +316,7 @@ private suspend inline fun KookComponentBot.pushIfProcessable(
 ): Boolean {
     if (eventProcessor.isProcessable(eventKey)) {
         val event = block() ?: return false
-        eventProcessor.push(event)
+        launch { eventProcessor.push(event) }
         return true
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.launch
 import love.forte.simbot.DiscreetSimbotApi
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
-import love.forte.simbot.component.kook.KookComponentBot
 import love.forte.simbot.component.kook.event.*
 import love.forte.simbot.component.kook.internal.event.*
 import love.forte.simbot.component.kook.model.toModel
@@ -310,13 +309,17 @@ private suspend fun KookComponentBotImpl.findUserInGuilds(userId: ID, guildIds: 
 }
 
 
-private suspend inline fun KookComponentBot.pushIfProcessable(
+private suspend inline fun KookComponentBotImpl.pushIfProcessable(
     eventKey: Key<*>,
     block: () -> love.forte.simbot.event.Event?,
 ): Boolean {
     if (eventProcessor.isProcessable(eventKey)) {
         val event = block() ?: return false
-        launch { eventProcessor.push(event) }
+        if (isEventProcessAsync) {
+            launch { eventProcessor.push(event) }
+        } else {
+            eventProcessor.push(event)
+        }
         return true
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
@@ -18,7 +18,6 @@
 package love.forte.simbot.component.kook.internal
 
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import love.forte.simbot.DiscreetSimbotApi
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
@@ -63,7 +62,7 @@ internal suspend fun Event<*>.register(bot: KookComponentBotImpl) {
 
 
 @OptIn(DiscreetSimbotApi::class)
-private fun Event<*>.pushUnsupported(bot: KookComponentBotImpl) {
+private suspend fun Event<*>.pushUnsupported(bot: KookComponentBotImpl) {
     bot.pushIfProcessable(UnsupportedKookEvent) {
         UnsupportedKookEvent(bot, this)
     }
@@ -72,7 +71,7 @@ private fun Event<*>.pushUnsupported(bot: KookComponentBotImpl) {
 /**
  * 消息事件
  */
-private fun MessageEvent<*>.registerMessageEvent(bot: KookComponentBotImpl) {
+private suspend fun MessageEvent<*>.registerMessageEvent(bot: KookComponentBotImpl) {
     when (channelType) {
         Channel.Type.PERSON -> {
             if (bot.isMe(authorId)) {
@@ -95,8 +94,8 @@ private fun MessageEvent<*>.registerMessageEvent(bot: KookComponentBotImpl) {
                     KookBotSelfChannelMessageEventImpl(
                         bot,
                         this,
-                        _channel = channel,
-                        _member = author
+                        channel,
+                        author
                     )
                 }
             } else {
@@ -310,13 +309,13 @@ private suspend fun KookComponentBotImpl.findUserInGuilds(userId: ID, guildIds: 
 }
 
 
-private inline fun KookComponentBot.pushIfProcessable(
+private suspend inline fun KookComponentBot.pushIfProcessable(
     eventKey: Key<*>,
     block: () -> love.forte.simbot.event.Event?,
 ): Boolean {
     if (eventProcessor.isProcessable(eventKey)) {
         val event = block() ?: return false
-        launch { eventProcessor.push(event) }
+        eventProcessor.push(event)
         return true
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
@@ -79,7 +79,7 @@ internal class KookChannelImpl private constructor(
     
     override suspend fun guild(): KookGuild = _guild
     
-    override suspend fun member(id: ID): KookGuildMember? = _guild.getMember(id)
+    override suspend fun member(id: ID): KookGuildMember? = _guild.member(id)
     
     override suspend fun send(message: Message, quote: ID?, tempTargetId: ID?): KookMessageReceipt {
         val request = message.toRequest(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId)

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
@@ -23,6 +23,7 @@ import love.forte.simbot.ID
 import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.component.kook.KookChannel
 import love.forte.simbot.component.kook.KookComponentGuildBot
+import love.forte.simbot.component.kook.KookGuild
 import love.forte.simbot.component.kook.KookGuildMember
 import love.forte.simbot.component.kook.message.*
 import love.forte.simbot.component.kook.message.KookMessageCreatedReceipt.Companion.asReceipt
@@ -47,39 +48,38 @@ internal interface MutableChannelModelContainer {
  */
 internal class KookChannelImpl private constructor(
     private val baseBot: KookComponentBotImpl,
-    override val guild: KookGuildImpl,
+    private val _guild: KookGuildImpl,
     @Volatile
     override var category: KookChannelCategoryImpl?,
     @Volatile override var source: ChannelModel,
 ) : KookChannel, CoroutineScope, MutableChannelModelContainer {
     
     override val bot: KookComponentGuildBot
-        get() = guild.bot
+        get() = _guild.bot
     
-    private val job = SupervisorJob(guild.job)
-    override val coroutineContext: CoroutineContext = guild.coroutineContext + job
+    private val job = SupervisorJob(_guild.job)
+    override val coroutineContext: CoroutineContext = _guild.coroutineContext + job
     
     override val guildId: ID
-        get() = guild.id
+        get() = _guild.id
     
     override val currentMember: Int
-        get() = guild.currentMember
+        get() = _guild.currentMember
     
     override val maximumMember: Int
-        get() = guild.maximumMember
+        get() = _guild.maximumMember
     
     override val ownerId: ID
-        get() = guild.ownerId
-    
-    override val owner: KookGuildMember
-        get() = guild.owner
+        get() = _guild.ownerId
     
     override val members: Items<KookGuildMember>
-        get() = guild.members
+        get() = _guild.members
     
-    override fun getMember(id: ID): KookGuildMember? = guild.getMember(id)
-    override suspend fun member(id: ID): KookGuildMember? = guild.member(id)
+    override suspend fun owner(): KookGuildMember = _guild.owner()
     
+    override suspend fun guild(): KookGuild = _guild
+    
+    override suspend fun member(id: ID): KookGuildMember? = _guild.getMember(id)
     
     override suspend fun send(message: Message, quote: ID?, tempTargetId: ID?): KookMessageReceipt {
         val request = message.toRequest(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId)
@@ -107,6 +107,7 @@ internal class KookChannelImpl private constructor(
                     tempTargetId = tempTargetId,
                 ).requestDataBy(baseBot).asReceipt(false, baseBot)
             }
+            
             is KookChannelMessageDetailsContent -> {
                 val details = message.details
                 MessageCreateRequest(
@@ -118,6 +119,7 @@ internal class KookChannelImpl private constructor(
                     tempTargetId = tempTargetId,
                 ).requestDataBy(baseBot).asReceipt(false, baseBot)
             }
+            
             else -> {
                 send(message.messages)
             }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -85,14 +85,6 @@ private class MuteDelayCoroutineDispatcherContainer(name: String) {
         it.isDaemon = true
     }
     
-    @Volatile
-    private var threadNum = 1
-    
-    @Synchronized
-    private fun nextThreadNum(): Int {
-        return threadNum++
-    }
-    
     val muteDelayDispatcher: ExecutorCoroutineDispatcher = ThreadPoolExecutor(
         0,
         1,
@@ -100,7 +92,7 @@ private class MuteDelayCoroutineDispatcherContainer(name: String) {
         TimeUnit.MINUTES,
         LinkedBlockingQueue(),
     ) { runnable ->
-        Thread(threadGroup, runnable, "${threadGroup.name}-${nextThreadNum()}").also {
+        Thread(threadGroup, runnable, threadGroup.name).also {
             it.isDaemon = true
         }
     }.asCoroutineDispatcher()

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -73,31 +73,9 @@ import love.forte.simbot.utils.item.itemsByFlow
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 import kotlin.collections.set
 import kotlin.coroutines.CoroutineContext
 import love.forte.simbot.kook.event.Event as KkEvent
-
-private class MuteDelayCoroutineDispatcherContainer(name: String) {
-    private val threadGroup = ThreadGroup(name).also {
-        it.isDaemon = true
-    }
-    
-    val muteDelayDispatcher: ExecutorCoroutineDispatcher = ThreadPoolExecutor(
-        0,
-        1,
-        1,
-        TimeUnit.MINUTES,
-        LinkedBlockingQueue(),
-    ) { runnable ->
-        Thread(threadGroup, runnable, threadGroup.name).also {
-            it.isDaemon = true
-        }
-    }.asCoroutineDispatcher()
-    
-}
 
 /**
  *
@@ -112,13 +90,13 @@ internal class KookComponentBotImpl(
 ) : KookComponentBot {
     internal val job = SupervisorJob(sourceBot.coroutineContext[Job]!!)
     override val coroutineContext: CoroutineContext = sourceBot.coroutineContext + job
+    
     override val logger: Logger =
         LoggerFactory.getLogger("love.forte.simbot.component.kook.bot.${sourceBot.ticket.clientId}")
     
-    private val muteDelayCoroutineDispatcherContainer =
-        MuteDelayCoroutineDispatcherContainer("muteDelay-bot-${sourceBot.ticket.clientId}")
+    internal val muteDelayJob = SupervisorJob(job)
     
-    internal val muteDelayCoroutineDispatcher get() = muteDelayCoroutineDispatcherContainer.muteDelayDispatcher
+    // internal val muteDelayCoroutineDispatcher get() = muteDelayCoroutineDispatcherContainer.muteDelayDispatcher
     
     private lateinit var internalGuilds: ConcurrentHashMap<String, KookGuildImpl>
     
@@ -316,8 +294,6 @@ internal class KookComponentBotImpl(
     
     override suspend fun guild(id: ID): KookGuildImpl? = internalGuilds[id.literal]
     
-    override fun getGuild(id: ID): KookGuildImpl? = internalGuilds[id.literal]
-    
     override val guildList: List<KookGuild>
         get() = internalGuilds.values.toList()
     
@@ -373,18 +349,7 @@ internal class KookComponentBotImpl(
         }
         return KookAssetImage(AssetCreated(id.literal))
     }
-    
-    /**
-     * 由于 Kook 中的资源不存在id，因此会直接将 [id] 视为 url 进行转化。
-     */
-    @OptIn(ApiResultType::class)
-    @JvmSynthetic
-    override fun resolveImageBlocking(id: ID): KookAssetImage {
-        Simbot.require(id.literal.startsWith(ASSET_PREFIX)) {
-            "The id must be the resource id of the kook and must start with $ASSET_PREFIX"
-        }
-        return KookAssetImage(AssetCreated(id.literal))
-    }
+
     
     override suspend fun uploadAssetImage(resource: Resource): KookAssetImage {
         val asset = AssetCreateRequest(resource).requestDataBy(this)
@@ -405,8 +370,8 @@ internal class KookComponentBotImpl(
                     // 某人退出频道服务器
                     // 在标准事件处理中进行
                     // is ExitedGuildEventBody -> {
-                        // val guild = internalGuild(this.targetId) ?: return
-                        // guild.internalMembers.remove(body.userId.literal)?.also { it.cancel() }
+                    // val guild = internalGuild(this.targetId) ?: return
+                    // guild.internalMembers.remove(body.userId.literal)?.also { it.cancel() }
                     // }
                     
                     // 某人加入频道服务器
@@ -514,7 +479,8 @@ internal class KookComponentBotImpl(
                         // TODO check isCategory?
                         guild(targetId)?.also { guild ->
                             val removedId = body.id.literal
-                            val removed: Any? = guild.removeInternalChannel(removedId) ?: guild.removeInternalCategory(removedId)
+                            val removed: Any? =
+                                guild.removeInternalChannel(removedId) ?: guild.removeInternalCategory(removedId)
                             logger.debug("Channel(or category) {} is be Deleted", removed)
                         }
                     }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -91,6 +91,8 @@ internal class KookComponentBotImpl(
     internal val job = SupervisorJob(sourceBot.coroutineContext[Job]!!)
     override val coroutineContext: CoroutineContext = sourceBot.coroutineContext + job
     
+    internal val isEventProcessAsync = sourceBot.configuration.isEventProcessAsync
+    
     override val logger: Logger =
         LoggerFactory.getLogger("love.forte.simbot.component.kook.bot.${sourceBot.ticket.clientId}")
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentGuildBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentGuildBotImpl.kt
@@ -17,9 +17,17 @@
 
 package love.forte.simbot.component.kook.internal
 
-import love.forte.simbot.component.kook.KookComponentBot
-import love.forte.simbot.component.kook.KookComponentGuildBot
-import love.forte.simbot.component.kook.KookGuildMember
+import love.forte.simbot.ID
+import love.forte.simbot.component.kook.*
+import love.forte.simbot.component.kook.message.KookAssetImage
+import love.forte.simbot.component.kook.message.KookSimpleAssetMessage
+import love.forte.simbot.event.EventProcessor
+import love.forte.simbot.kook.KookBot
+import love.forte.simbot.kook.api.message.MessageType
+import love.forte.simbot.resources.Resource
+import love.forte.simbot.utils.item.Items
+import org.slf4j.Logger
+import kotlin.coroutines.CoroutineContext
 
 
 /**
@@ -29,11 +37,65 @@ import love.forte.simbot.component.kook.KookGuildMember
 internal class KookComponentGuildBotImpl private constructor(
     override val bot: KookComponentBot,
     private val member: KookGuildMember,
-) : KookComponentGuildBot(), KookComponentBot by bot {
+) : KookComponentGuildBot() {
     override suspend fun asMember(): KookGuildMember = member
     
-    override fun toMember(): KookGuildMember = member
+    override suspend fun guild(id: ID): KookGuild? = bot.guild(id)
     
+    override suspend fun contact(id: ID): KookUserChat = bot.contact(id)
+    
+    override suspend fun resolveImage(id: ID): KookAssetImage = bot.resolveImage(id)
+    
+    override suspend fun uploadAsset(resource: Resource, type: Int): KookSimpleAssetMessage =
+        bot.uploadAsset(resource, type)
+    
+    override suspend fun uploadAsset(resource: Resource, type: MessageType): KookSimpleAssetMessage =
+        bot.uploadAsset(resource, type)
+    
+    override suspend fun uploadAssetImage(resource: Resource): KookAssetImage = bot.uploadAssetImage(resource)
+    
+    override fun isMe(id: ID): Boolean = bot.isMe(id)
+    
+    override val sourceBot: KookBot
+        get() = bot.sourceBot
+    override val component: KookComponent
+        get() = bot.component
+    override val avatar: String
+        get() = bot.avatar
+    override val coroutineContext: CoroutineContext
+        get() = bot.coroutineContext
+    override val eventProcessor: EventProcessor
+        get() = bot.eventProcessor
+    override val isActive: Boolean
+        get() = bot.isActive
+    override val isCancelled: Boolean
+        get() = bot.isCancelled
+    override val isStarted: Boolean
+        get() = bot.isStarted
+    override val logger: Logger
+        get() = bot.logger
+    override val manager: KookBotManager
+        get() = bot.manager
+    override val username: String
+        get() = bot.username
+    override val guilds: Items<KookGuild>
+        get() = bot.guilds
+    override val guildList: List<KookGuild>
+        get() = bot.guildList
+    override val contacts: Items<KookUserChat>
+        get() = bot.contacts
+    
+    override suspend fun cancel(reason: Throwable?): Boolean {
+        return bot.cancel(reason)
+    }
+    
+    override suspend fun join() {
+        bot.join()
+    }
+    
+    override suspend fun start(): Boolean {
+        return bot.start()
+    }
     
     override fun toString(): String {
         return "KookComponentGuildBotImpl(bot=$bot, member=$member)"

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
@@ -41,7 +41,6 @@ import love.forte.simbot.kook.api.user.UserViewRequest
 import love.forte.simbot.literal
 import love.forte.simbot.utils.item.Items
 import love.forte.simbot.utils.item.Items.Companion.asItems
-import love.forte.simbot.utils.runInBlocking
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 
@@ -159,27 +158,18 @@ internal class KookGuildImpl private constructor(
         return syncLastOwnerMember(ownerId.literal)
     }
     
-    override val owner: KookGuildMember
-        get() {
-            val ownerId = ownerId
-            if (lastOwnerMember.id == ownerId) {
-                return lastOwnerMember
-            }
-            return runInBlocking { syncLastOwnerMember(ownerId.literal) }
-        }
-    
     override val members: Items<KookGuildMember>
         get() = internalMembers.values.asItems()
     
     override val memberList: List<KookGuildMember>
         get() = internalMembers.values.toList()
     
-    override fun getMember(id: ID): KookGuildMember? = internalMembers[id.literal]
+    override suspend fun member(id: ID): KookGuildMember? = internalMembers[id.literal]
     
     override val channels: Items<KookChannel>
         get() = internalChannels.values.asItems()
     
-    override fun getChannel(id: ID): KookChannel? = internalChannels[id.literal]
+    override suspend fun channel(id: ID): KookChannel? = internalChannels[id.literal]
     
     override val channelList: List<KookChannel>
         get() = internalChannels.values.toList()

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
@@ -23,6 +23,7 @@ import love.forte.simbot.component.kook.KookUserChat
 import love.forte.simbot.component.kook.message.*
 import love.forte.simbot.component.kook.message.KookMessageCreatedReceipt.Companion.asReceipt
 import love.forte.simbot.component.kook.model.UserChatViewModel
+import love.forte.simbot.component.kook.util.requestBy
 import love.forte.simbot.component.kook.util.requestDataBy
 import love.forte.simbot.kook.api.message.DirectMessageCreateRequest
 import love.forte.simbot.kook.api.message.MessageCreated
@@ -92,7 +93,6 @@ internal class KookUserChatImpl(
     }
     
     override suspend fun delete(): Boolean {
-        UserChatDeleteRequest(id).requestDataBy(bot)
-        return true
+        return UserChatDeleteRequest(id).requestBy(bot).isSuccess
     }
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
@@ -22,13 +22,13 @@ import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.component.kook.KookUserChat
 import love.forte.simbot.component.kook.message.*
 import love.forte.simbot.component.kook.message.KookMessageCreatedReceipt.Companion.asReceipt
-import love.forte.simbot.component.kook.model.UserChatViewModel
 import love.forte.simbot.component.kook.util.requestBy
 import love.forte.simbot.component.kook.util.requestDataBy
 import love.forte.simbot.kook.api.message.DirectMessageCreateRequest
 import love.forte.simbot.kook.api.message.MessageCreated
 import love.forte.simbot.kook.api.message.MessageType
 import love.forte.simbot.kook.api.userchat.UserChatDeleteRequest
+import love.forte.simbot.kook.api.userchat.UserChatView
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 
@@ -37,7 +37,7 @@ import love.forte.simbot.message.MessageContent
  * @author ForteScarlet
  */
 internal class KookUserChatImpl(
-    override val bot: KookComponentBotImpl, @Volatile override var source: UserChatViewModel,
+    override val bot: KookComponentBotImpl, override val source: UserChatView,
 ) : KookUserChat {
     override val id: ID
         get() = source.targetInfo.id

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
@@ -193,7 +193,7 @@ private suspend fun Message.Element<*>.elementToRequestOrNull(
 
         // 需要上传的图片
         is ResourceImage -> {
-            val asset = AssetCreateRequest(resource).requestDataBy(bot)
+            val asset = AssetCreateRequest(resource()).requestDataBy(bot)
             request(MessageType.IMAGE.type, asset.url)
         }
 

--- a/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBotConfiguration.kt
+++ b/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBotConfiguration.kt
@@ -37,32 +37,32 @@ public annotation class KookBotConfigurationDSL
  * @author ForteScarlet
  */
 public class KookBotConfiguration {
-
+    
     /**
      * 设置bot进行连接的时候使用要使用压缩数据。
      */
     @KookBotConfigurationDSL
     public var isCompress: Boolean = true
-
+    
     /**
      * Bot用于解析api请求或其他用途的解析器。
      */
     @KookBotConfigurationDSL
     public var decoder: Json = defaultDecoder
-
+    
     /**
      * 为bot提供一个 [CoroutineContext]. 如果其中存在 [kotlinx.coroutines.Job], 则会作为parent job。
      */
     @KookBotConfigurationDSL
     public var coroutineContext: CoroutineContext = EmptyCoroutineContext
-
-
+    
+    
     /**
      * 配置bot内部要使用的client Engine。
      */
     @KookBotConfigurationDSL
     public var clientEngine: HttpClientEngine? = null
-
+    
     /**
      * 配置bot内部要使用的client Engine factory。
      *
@@ -70,39 +70,90 @@ public class KookBotConfiguration {
      */
     @KookBotConfigurationDSL
     public var clientEngineFactory: HttpClientEngineFactory<*>? = null
-
+    
     /**
      * 配置bot内部要使用的httpclient。
      *
      * 默认情况下的client中已经install了
      * [ContentNegotiation][io.ktor.client.plugins.contentnegotiation.ContentNegotiation.Plugin] 中的 `json`
-     * 和
-     * [WebSockets][io.ktor.client.plugins.websocket.WebSockets.Plugin].
-     *
      */
     @KookBotConfigurationDSL
     public var httpClientConfig: HttpClientConfig<*>.() -> Unit = {}
-
-
+    
+    
     /**
      * 配置bot内部要使用的httpclient。
      *
      * 默认情况下的client中已经install了
      * [ContentNegotiation][io.ktor.client.plugins.contentnegotiation.ContentNegotiation.Plugin] 中的 `json`
-     * 和
-     * [WebSockets][io.ktor.client.plugins.websocket.WebSockets.Plugin].
      */
     @KookBotConfigurationDSL
     public fun httpClientConfig(block: HttpClientConfig<*>.() -> Unit) {
         this.httpClientConfig = block
     }
-
+    
+    /**
+     * api请求的超时配置。
+     * 如果为null则不会在 `httpClient` 中安装 [io.ktor.client.plugins.HttpTimeout]。
+     */
+    @KookBotConfigurationDSL
+    public var timeout: TimeoutConfiguration? = TimeoutConfiguration(
+        connectTimeoutMillis = 5000L,
+        requestTimeoutMillis = 5000L,
+        socketTimeoutMillis = null,
+    )
+    
+    /**
+     * 禁用超时配置。
+      */
+    @KookBotConfigurationDSL
+    public fun disableTimeout() {
+        timeout = null
+    }
+    
+    /**
+     * api请求的连接超时时间。
+     */
+    @KookBotConfigurationDSL
+    public var connectTimeoutMillis: Long?
+        get() = timeout?.connectTimeoutMillis
+        set(value) {
+            timeout?.let { t -> t.connectTimeoutMillis = value } ?: apply {
+                timeout = TimeoutConfiguration(connectTimeoutMillis = value)
+            }
+        }
+    
+    /**
+     * api请求的请求超时时间。
+     */
+    @KookBotConfigurationDSL
+    public var requestTimeoutMillis: Long?
+        get() = timeout?.requestTimeoutMillis
+        set(value) {
+            timeout?.let { t -> t.requestTimeoutMillis = value } ?: apply {
+                timeout = TimeoutConfiguration(requestTimeoutMillis = value)
+            }
+        }
+    
+    /**
+     * api请求的请求超时时间。
+     */
+    @KookBotConfigurationDSL
+    public var socketTimeoutMillis: Long?
+        get() = timeout?.socketTimeoutMillis
+        set(value) {
+            timeout?.let { t -> t.socketTimeoutMillis = value } ?: apply {
+                timeout = TimeoutConfiguration(socketTimeoutMillis = value)
+            }
+        }
+    
+    
     /**
      * 在执行 [KookBot.start] 建立连接成功后、进行事件处理之前执行此函数。
      */
     public var preEventProcessor: suspend (bot: KookBot, sessionId: String) -> Unit = { _, _ -> }
-
-
+    
+    
     /**
      * 在执行 [KookBot.start] 建立连接成功后、进行事件处理之前执行此函数。
      */
@@ -110,8 +161,8 @@ public class KookBotConfiguration {
     public fun preEventProcessor(block: suspend (bot: KookBot, sessionId: String) -> Unit) {
         this.preEventProcessor = block
     }
-
-
+    
+    
     public companion object {
         /**
          * [KookBotConfiguration] 默认使用的解析器。
@@ -119,6 +170,36 @@ public class KookBotConfiguration {
         public val defaultDecoder: Json = Json {
             isLenient = true
             ignoreUnknownKeys = true
+            encodeDefaults = true
         }
+    }
+    
+    /**
+     * api请求的统一超时时间配置。
+     */
+    public data class TimeoutConfiguration(
+        var connectTimeoutMillis: Long? = null,
+        var requestTimeoutMillis: Long? = null,
+        var socketTimeoutMillis: Long? = null,
+    ) {
+        public constructor() : this(null, null, null)
+    }
+}
+
+
+/**
+ * 配置 [KookBotConfiguration.timeout]。
+ *
+ * 只有当 [timeout][KookBotConfiguration.timeout] 不为null时或者 [init] == true 时才会触发。
+ *
+ * @param init 如果 timeout 为null且 [init] 为true，则会初始化一个 [timeout][KookBotConfiguration.timeout]
+ *
+ */
+public inline fun KookBotConfiguration.timeout(init: Boolean = true, block: KookBotConfiguration.TimeoutConfiguration.() -> Unit) {
+    val timeout = this.timeout
+    if (timeout == null) {
+        this.timeout = KookBotConfiguration.TimeoutConfiguration().also(block)
+    } else {
+        timeout.block()
     }
 }

--- a/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBotConfiguration.kt
+++ b/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBotConfiguration.kt
@@ -197,9 +197,9 @@ public class KookBotConfiguration {
  */
 public inline fun KookBotConfiguration.timeout(init: Boolean = true, block: KookBotConfiguration.TimeoutConfiguration.() -> Unit) {
     val timeout = this.timeout
-    if (timeout == null) {
+    if (timeout == null && init) {
         this.timeout = KookBotConfiguration.TimeoutConfiguration().also(block)
     } else {
-        timeout.block()
+        timeout?.block()
     }
 }

--- a/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/internal/KookBotImpl.kt
+++ b/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/internal/KookBotImpl.kt
@@ -21,11 +21,15 @@ import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.websocket.*
-import io.ktor.client.request.*
+import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
@@ -45,13 +49,14 @@ import love.forte.simbot.kook.event.*
 import love.forte.simbot.kook.requestDataBy
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.zip.InflaterInputStream
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
 import kotlin.math.max
+import kotlin.time.Duration.Companion.seconds
 
 /**
  *
@@ -167,37 +172,705 @@ internal class KookBotImpl(
     @Volatile
     private var client: ClientImpl? = null
     
-    private val _isStarted: AtomicBoolean = AtomicBoolean(false)
+    @Volatile
+    private var stageLoop: StageLoop? = null
     
-    override val isStarted: Boolean
-        get() = _isStarted.get()
+    @Volatile
+    override var isStarted: Boolean = false
     
-    override suspend fun start(): Boolean = start { null }
+    private val clientLock = Mutex()
     
-    private suspend inline fun start(reason: () -> Throwable?): Boolean {
+    override suspend fun start(): Boolean = clientLock.withLock {
         if (job.isCancelled) {
             throw kotlinx.coroutines.CancellationException("Bot has been cancelled.")
         }
         
-        val c = client
-        if (c != null) {
-            clientLogger.debug("Closing the current client: {}", c)
-            c.cancel(reason())
-            clientLogger.debug("Current client closed.")
-            client = null
+        clientLogger.debug("Closing the current client: {}", client)
+        stageLoop?.job?.cancel()
+        client?.session?.cancel()
+        stageLoop = null
+        client = null
+        
+        val loopJob = SupervisorJob(job)
+        
+        val loop = StageLoop(loopJob)
+        logger.debug("Create stage loop {}", loop)
+        
+        loop.addLast(RequestGateway())
+        
+        var next = loop.nextStage()
+        while (next != null && next !is Receive) {
+            // 还没到receive阶段
+            loop.invoke(next)
+            next = loop.nextStage()
         }
         
-        clientLogger.debug("Requesting for gateway info...")
-        val gateway = gatewayRequest.requestDataBy(this)
+        logger.debug("Loop on stage 'Receive'")
         
-        clientLogger.debug("Creating client by gateway {}", gateway)
-        client = createClient(gateway, wsConnectTimeout)
+        launch(loopJob) {
+            loop.invoke(next)
+            loop.run()
+        }
         
-        clientLogger.debug("Client created. client: {}", client)
-        _isStarted.compareAndSet(false, true)
-        
-        return true
+        isStarted = true
+        true
     }
+    
+    
+    /**
+     * 通过 [Gateway] 连接bot信息。
+     */
+    private suspend fun HttpClient.ws(gateway: GatewayInfo): DefaultClientWebSocketSession {
+        return webSocketSession {
+            url {
+                takeFrom(gateway.url)
+                gateway.apply {
+                    urlBuilder()
+                }
+            }
+        }
+    }
+    
+    private suspend inline fun DefaultClientWebSocketSession.waitHello(): Signal.Hello {
+        // receive Hello
+        var hello: Signal.Hello? = null
+        while (isActive) {
+            val h = waitForHello(decoder, incoming.receive())
+            if (h != null) {
+                hello = h
+                break
+            }
+        }
+        if (hello == null) {
+            closeReason.await().err()
+        }
+        return hello
+    }
+    
+    private suspend fun DefaultClientWebSocketSession.heartbeatJob(sn: AtomicLong): HeartbeatJob {
+        val heartbeatInterval = 30_000 // 30s
+        fun helloInterval(): Long {
+            val r = kotlin.random.Random.nextLong(5000)
+            return if (kotlin.random.Random.nextBoolean()) heartbeatInterval + r else heartbeatInterval - r
+        }
+        
+        val lateinitWaiter = CompletableDeferred<CancellableContinuation<HeartbeatJob>>()
+        
+        // heartbeat Job
+        val heartbeatLaunchJob = launch {
+            val heartbeatJob = suspendCancellableCoroutine { continuation ->
+                lateinitWaiter.complete(continuation)
+            }
+            
+            val serializer = Signal.Ping.serializer()
+            while (isActive) {
+                delay(helloInterval())
+                val hb = Signal.Ping(sn.get())
+                send(decoder.encodeToString(serializer, hb))
+                // wait for pong
+                try {
+                    // 如果超时:
+                    // 在连接中，每隔 30 秒发一次心跳 ping 包，如果 6 秒内，没有收到心跳 pong 包，则超时。进入到指数回退，重试。
+                    val pong = withTimeout(6.seconds) {
+                        suspendCancellableCoroutine { continuation ->
+                            heartbeatJob.resetPongReceiver { old ->
+                                if (old?.isActive == true) {
+                                    old.cancel()
+                                }
+                                continuation
+                            }
+                        }
+                    }
+                    
+                    logger.debug("Received pong {} in 6s", pong)
+                } catch (timeout: TimeoutCancellationException) {
+                    // timeout for waiting pong!
+                    cancel("pong receive timeout: ${timeout.localizedMessage}", timeout)
+                }
+            }
+        }
+        
+        val heartbeatJob = HeartbeatJob(heartbeatLaunchJob)
+        lateinitWaiter.await().resume(heartbeatJob)
+        
+        return heartbeatJob
+    }
+    
+    private class HeartbeatJob(val job: Job) {
+        private var pongReceiver: CancellableContinuation<Signal.Pong>? = null
+        
+        @Synchronized
+        fun resetPongReceiver(update: (old: CancellableContinuation<Signal.Pong>?) -> CancellableContinuation<Signal.Pong>) {
+            val old = pongReceiver
+            pongReceiver = update(old)
+        }
+        
+        @Synchronized
+        fun pong(pong: Signal.Pong) {
+            pongReceiver?.resume(pong)
+        }
+        
+        override fun toString(): String {
+            return "HeartbeatJob(job=$job)"
+        }
+    }
+    
+    override suspend fun join() {
+        job.join()
+    }
+    
+    override suspend fun cancel(reason: Throwable?) {
+        if (job.isCancelled) {
+            return
+        }
+        
+        if (reason == null) {
+            job.cancel()
+        } else {
+            job.cancel(reason.localizedMessage, reason)
+        }
+        
+        job.join()
+    }
+    
+    // private inner class ClientImpl(
+    //     // private val job: Job,
+    //     override val url: String,
+    //     private val sessionData: Signal.Hello,
+    //     private val _sn: AtomicLong,
+    //     private var session: DefaultClientWebSocketSession,
+    // ) : KookBot.Client {
+    //     override val sn: Long get() = _sn.get()
+    //
+    //     override val isActive: Boolean get() = session.isActive
+    //     // override val isResuming: Boolean get() = _resuming.get()
+    //
+    //     override val bot: KookBot
+    //         get() = this@KookBotImpl
+    //
+    //     override val isCompress: Boolean
+    //         get() = this@KookBotImpl.isCompress
+    //
+    //
+    //     suspend fun cancel(reason: Throwable? = null) {
+    //         val cancel = reason?.let { CancellationException(it.localizedMessage, it) }
+    //
+    //         val sessionJob = session.coroutineContext[Job]!!
+    //         sessionJob.cancel(cancel)
+    //         sessionJob.join()
+    //     }
+    //
+    //     override fun toString(): String {
+    //         return "Client(url=$url, sn=$sn, sessionId=${sessionData.d.sessionId})"
+    //     }
+    //
+    // }
+    
+    
+    override suspend fun me(): Me {
+        return MeRequest.requestDataBy(this)
+    }
+    
+    override suspend fun offline() {
+        return OfflineRequest.requestDataBy(this)
+    }
+    
+    private class GatewayInfo(val url: String, val urlBuilder: URLBuilder.() -> Unit = {})
+    
+    private fun Gateway.info(urlBuilder: URLBuilder.() -> Unit = {}): GatewayInfo = GatewayInfo(url, urlBuilder)
+    
+    data class ReconnectInfo(val sn: Long, val sessionId: String)
+    
+    private open inner class Stage {
+        open suspend operator fun invoke(loop: StageLoop) {
+        }
+    }
+    
+    
+    /**
+     * 请求并获取gateway信息。
+     * @property time 当前获取gateway的次数。大于1时代表本次为某次的重试。
+     */
+    private inner class RequestGateway(
+        val time: Int = 1,
+        val reconnectInfo: ReconnectInfo? = null,
+    ) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            clientLogger.debug("Requesting for gateway info... time: {}", time)
+            // retry on failure?
+            val gateway = gatewayRequest.requestDataBy(this@KookBotImpl)
+            
+            // next: create session
+            if (reconnectInfo != null) {
+                loop.addLast(CreateWsSession(RequestedGateway(this, gateway.info {
+                    parameters["session_id"] = reconnectInfo.sessionId
+                    parameters["sn"] = reconnectInfo.sn.toString()
+                    parameters["resume"] = "1"
+                })))
+            } else {
+                loop.addLast(CreateWsSession(RequestedGateway(this, gateway.info())))
+            }
+        }
+    }
+    
+    private inner class RequestedGateway(val stage: RequestGateway, val gateway: GatewayInfo)
+    
+    /**
+     * ws 连接到 gateway
+     *
+     * > 2: 连接 Gateway。如果连接失败，回退到第 1 步。
+     *
+     */
+    private inner class CreateWsSession(val gateway: RequestedGateway) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            clientLogger.debug("Creating websocket session...")
+            try {
+                val session = connectWs()
+                
+                // next: waiting hello?
+                // next: create client
+                loop.addLast(WaitingHello(gateway, session))
+            } catch (e: Throwable) {
+                if (clientLogger.isDebugEnabled) {
+                    clientLogger.error("Connect to gateway failed, retry.", e)
+                } else {
+                    clientLogger.error("Connect to gateway [{}] failed, retry.", gateway, e)
+                }
+                // retry
+                loop.addLast(
+                    RequestGateway(
+                        time = gateway.stage.time + 1,
+                        reconnectInfo = gateway.stage.reconnectInfo
+                    )
+                )
+            }
+        }
+        
+        private suspend fun connectWs(): DefaultClientWebSocketSession {
+            return wsClient.ws(gateway.gateway)
+        }
+    }
+    
+    /**
+     *
+     * [CreateWsSession] 之后，等待 `Hello` 包。期间如果出现其他什么包，抛弃。
+     *
+     * > 3: 收到 hello 包，如果成功，开始接收事件。如果失败，回退至第 1 步。
+     */
+    private inner class WaitingHello(val gatewayStage: RequestedGateway, val wsSession: DefaultClientWebSocketSession) :
+        Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            clientLogger.debug("Waiting for 'Hello'")
+            val hello: Signal.Hello = try {
+                withTimeout(wsConnectTimeout) {
+                    wsSession.waitHello()
+                }.apply {
+                    // KookApiException()
+                    // just throw..?
+                    check()
+                }
+            } catch (timeout: TimeoutCancellationException) {
+                wsSession.cancel("'Hello' receive timeout, reconnect.", timeout)
+                // next: back to gateway
+                // 回退到第 1 步
+                loop.addLast(
+                    RequestGateway(
+                        time = gatewayStage.stage.time + 1,
+                        reconnectInfo = gatewayStage.stage.reconnectInfo
+                    )
+                )
+                return
+            }
+            clientLogger.debug("Received 'Hello': {}, ready to process event.", hello)
+            
+            // create heart beat job
+            // event process (create client)
+            loop.addLast(CreateHeartbeatJob(gatewayStage, wsSession, hello, AtomicLong(0)))
+        }
+    }
+    
+    
+    /**
+     * 创建心跳收发器
+     */
+    private inner class CreateHeartbeatJob(
+        private val gatewayStage: RequestedGateway,
+        private val session: DefaultClientWebSocketSession,
+        private val hello: Signal.Hello,
+        private val sn: AtomicLong,
+    ) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            clientLogger.debug("Create heartbeat job")
+            val heartbeatJob = session.heartbeatJob(sn)
+            // next: create client
+            loop.addLast(CreateClient(gatewayStage, session, hello, sn, heartbeatJob))
+        }
+    }
+    
+    /**
+     * 创建一个 [ClientImpl], 并在其中异步的处理事件。
+     */
+    private inner class CreateClient(
+        private val gatewayStage: RequestedGateway,
+        private val session: DefaultClientWebSocketSession,
+        private val hello: Signal.Hello,
+        private val sn: AtomicLong,
+        private val heartbeatJob: HeartbeatJob,
+    ) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            val eventProcessChannel = Channel<Signal.Event>(capacity = Channel.BUFFERED)
+            
+            val job = session.eventProcessJob(sn, eventProcessChannel)
+            
+            val client = ClientImpl(gatewayStage.gateway, session, sn, heartbeatJob, job)
+            
+            // next: receive
+            loop.addLast(Receive(hello, client))
+        }
+    }
+    
+    /**
+     * 连接成功后构建client，并开始接收处理信息。
+     * client中事件在 flow 中异步处理，而 pong、reconnect等信令优先处理。
+     */
+    private inner class Receive(
+        private val hello: Signal.Hello,
+        private val client: ClientImpl,
+    ) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            // 接收
+            val frame = client.session.incoming.receive()
+            clientLogger.trace("Received frame: {}", frame)
+            when (frame) {
+                is Frame.Text -> processString(frame.readToText(), loop)
+                is Frame.Binary -> processString(frame.readToText(), loop)
+                
+                else -> {
+                    clientLogger.trace("Other frame: {}", frame)
+                }
+            }
+            
+            // 下一个还是自己
+            loop.addLast(this)
+        }
+        
+        private suspend fun processString(eventString: String, loop: StageLoop) {
+            val jsonElement = decoder.parseToJsonElement(eventString)
+            
+            fun <T> decode(strategy: DeserializationStrategy<T>): T {
+                return decoder.decodeFromJsonElement(strategy, jsonElement)
+            }
+            
+            // maybe op 11: heartbeat ack
+            val s = jsonElement.jsonObject["s"]?.jsonPrimitive?.intOrNull ?: return
+            
+            clientLogger.trace("On signal json: {}", jsonElement)
+            
+            when (s) {
+                // Pong.
+                Signal.Pong.S_CODE -> {
+                    client.heartbeatJob.pong(decoder.decodeFromJsonElement(Signal.Pong.serializer(), jsonElement))
+                }
+                
+                // Reconnect.
+                Signal.Reconnect.S_CODE -> {
+                    clientLogger.debug("Reconnect signal received: {}", eventString)
+                    val reconnect = decoder.decodeFromJsonElement(Signal.Reconnect.serializer(), jsonElement)
+                    val reconnectData = reconnect.data
+                    client.session.cancel(
+                        reconnectData.err ?: "reconnect",
+                        ReconnectException(reconnectData.code, reconnectData.err ?: "")
+                    )
+                    // next: reconnect
+                    loop.addLast(Reconnect(client.atomicSn.get(), hello.data.sessionId))
+                }
+                // Event
+                Signal.Event.S_CODE -> {
+                    // is dispatch
+                    val event = decode(Signal.Event.serializer())
+                    clientLogger.trace("On event signal: {}", event)
+                    client.eventProcessJob.eventChannel.apply {
+                        var success = false
+                        // try to send 3 times
+                        for (i in 1..3) {
+                            val sendResult = trySend(event)
+                            if (sendResult.isSuccess) {
+                                success = true
+                                break
+                            }
+                            
+                            if (sendResult.isFailure && !sendResult.isClosed) {
+                                // retry
+                                continue
+                            }
+                            
+                            if (sendResult.isClosed) {
+                                return
+                            }
+                        }
+                        
+                        if (!success) {
+                            send(event)
+                        }
+                    }
+                }
+                
+                
+            }
+        }
+    }
+    
+    /**
+     * 重连
+     */
+    private inner class Reconnect(
+        val sn: Long,
+        val sessionId: String,
+    ) : Stage() {
+        override suspend fun invoke(loop: StageLoop) {
+            loop.addLast(RequestGateway(reconnectInfo = ReconnectInfo(sn, sessionId)))
+        }
+    }
+    
+    // inner class Stop : Stage()
+    
+    private inner class StageLoop(
+        val job: Job,
+        val stageDeque: ConcurrentLinkedDeque<Stage> = ConcurrentLinkedDeque(),
+    ) {
+        @Volatile
+        var currentStage: Stage? = null
+            private set
+        
+        fun addLast(stage: Stage) {
+            stageDeque.addLast(stage)
+        }
+        
+        suspend fun run() {
+            var next = nextStage()
+            while (job.isActive && next != null) {
+                invoke(next)
+                next = nextStage()
+            }
+            logger.debug("Stage loop done. last stage: {}", currentStage)
+            currentStage = null
+        }
+        
+        suspend fun invoke(stage: Stage?) {
+            currentStage = stage
+            if (stage != null) {
+                stage(this)
+            }
+        }
+        
+        fun nextStage(): Stage? = stageDeque.pollFirst()
+        
+    }
+    
+    /**
+     * 连接成功的client。
+     */
+    private inner class ClientImpl(
+        val gatewayInfo: GatewayInfo,
+        
+        val session: DefaultClientWebSocketSession,
+        
+        /**
+         * sn
+         */
+        val atomicSn: AtomicLong,
+        
+        /**
+         * 心跳Job
+         */
+        val heartbeatJob: HeartbeatJob,
+        
+        /**
+         * 事件通道
+         */
+        val eventProcessJob: EventProcessJob,
+    ) : KookBot.Client {
+        override val sn: Long
+            get() = atomicSn.get()
+        override val isCompress: Boolean
+            get() = this@KookBotImpl.isCompress
+        override val bot: KookBot
+            get() = this@KookBotImpl
+        override val url: String
+            get() = gatewayInfo.url
+        override val isActive: Boolean
+            get() = session.isActive
+        
+        override fun toString(): String {
+            return "ClientImpl(sn=$sn, isCompress=$isCompress, heartbeatJob=$heartbeatJob, eventProcessJob=$eventProcessJob, bot=$bot)"
+        }
+        
+    }
+    
+    private fun DefaultClientWebSocketSession.eventProcessJob(
+        sn: AtomicLong,
+        eventChannel: Channel<Signal.Event>,
+    ): EventProcessJob {
+        val launchJob = eventChannel.receiveAsFlow().onEach { event ->
+            val nowSn = event.sn
+            // val currPreProcessorQueue = preProcessorQueue
+            // val currProcessorQueue = processorQueue
+            if (preProcessorQueue.isNotEmpty() || processorQueue.isNotEmpty()) {
+                clientLogger.trace("On event: {}", event)
+                val eventType = event.type
+                val eventExtraType = event.extraType
+                
+                // Event(s=0,
+                // d={"channel_type":"GROUP","type":9,"target_id":"4587833303764121","author_id":"2371258185","content":"我是RBQ",
+                // "extra":{"type":1,
+                // "code":"","guild_id":"8582739890554982","channel_name":"查价bot (机器人)","author":{"id":"2371258185","username":"芦苇测试机","identify_num":"5173","online":true,"os":"Websocket","status":0,"avatar":"https://img.kaiheila.cn/assets/bot.png/icon","vip_avatar":"https://img.kaiheila.cn/assets/bot.png/icon","banner":"","nickname":"芦苇测试机","roles":[2842315],"is_vip":false,"is_ai_reduce_noise":false,"bot":true,"tag_info":{"color":"#34A853","text":"机器人"},"client_id":"OPYfwS3t0hPuVZZx"},"mention":[],"mention_all":false,"mention_roles":[],"mention_here":false,"nav_channels":[],"kmarkdown":{"raw_content":"我是RBQ","mention_part":[],"mention_role_part":[]},"last_msg_content":"芦苇测试机：我是RBQ"},"msg_id":"ee8b14c1-22eb-44d3-bb65-a1274ade96db","msg_timestamp":1650354611204,"nonce":"","from_type":1}, sn=2)
+                
+                val parser = EventSignals[eventType, eventExtraType] ?: run {
+                    val e =
+                        SimbotIllegalStateException("Unknown event type: $eventType, subType: $eventExtraType. data: $event")
+                    clientLogger.error(e.localizedMessage, e)
+                    // e.process(logger) { "Event receiving" } // TODO process exception?
+                    return@onEach
+                }
+                
+                val lazy = lazy(LazyThreadSafetyMode.PUBLICATION) {
+                    parser.deserialize(decoder, event.d)
+                }
+                
+                val lazyDecoded = lazy::value
+                
+                // pre process
+                preProcessorQueue.forEach { pre ->
+                    try {
+                        pre(event, decoder, lazyDecoded)
+                    } catch (e: Throwable) {
+                        if (clientLogger.isDebugEnabled) {
+                            clientLogger.debug(
+                                "Event pre precess failure. Event: {}, event.data: {}", event, event.data
+                            )
+                        }
+                        clientLogger.error("Event pre precess failure.", e)
+                    }
+                }
+                
+                if (isEventProcessAsync) {
+                    launch {
+                        processorQueue.forEach { processor ->
+                            try {
+                                processor(event, decoder, lazyDecoded)
+                            } catch (e: Throwable) {
+                                clientLogger.debug(
+                                    "Event precess failure. Event: {}, event.data: {}", event, event.data, e
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    processorQueue.forEach { processor ->
+                        try {
+                            processor(event, decoder, lazyDecoded)
+                        } catch (e: Throwable) {
+                            clientLogger.debug(
+                                "Event precess failure. Event: {}, event.data: {}", event, event.data, e
+                            )
+                        }
+                    }
+                }
+            }
+            
+            // 留下最大值。
+            val currentSn = sn.updateAndGet { prev -> max(prev, nowSn) }
+            clientLogger.trace("Current sn: {}", currentSn)
+        }.onCompletion { cause ->
+            clientLogger.debug(
+                "Session flow completion. cause: {}", cause?.localizedMessage, cause
+            )
+        }.catch { cause ->
+            clientLogger.error(
+                "Session flow on error: {}", cause.localizedMessage, cause
+            )
+        }.launchIn(this)
+        
+        return EventProcessJob(launchJob, eventChannel)
+    }
+    
+    private class EventProcessJob(
+        val job: Job,
+        val eventChannel: Channel<Signal.Event>,
+    ) {
+        override fun toString(): String {
+            return "EventProcessJob(job=$job, eventChannel=$eventChannel)"
+        }
+    }
+    
+    companion object
+    
+}
+
+
+// private data class SessionInfo(
+//     val session: DefaultClientWebSocketSession,
+//     val sn: AtomicLong,
+//     val heartbeatJob: Job,
+//     val sessionData: Signal.Hello,
+// )
+
+/**
+ * 将 [Frame.Text] 读取为文字字符串。
+ */
+private fun Frame.Text.readToText(): String {
+    return readText()
+}
+
+/**
+ * 将 [Frame.Binary] 读取为文字字符串。
+ */
+private fun Frame.Binary.readToText(): String {
+    return InflaterInputStream(readBytes().inputStream()).bufferedReader().use { it.readText() }
+}
+
+private fun Frame.readToText(): String {
+    return when (this) {
+        is Frame.Text -> readToText()
+        is Frame.Binary -> readToText()
+        else -> throw SimbotIllegalArgumentException("Frame is not text or binary type.")
+    }
+}
+
+
+private fun waitForHello(decoder: Json, frame: Frame): Signal.Hello? {
+    var hello: Signal.Hello? = null
+    // for hello
+    
+    if (frame is Frame.Text || frame is Frame.Binary) {
+        val json = decoder.parseToJsonElement(frame.readToText())
+        if (json.jsonObject["s"]?.jsonPrimitive?.intOrNull == Signal.Hello.S_CODE) {
+            hello = decoder.decodeFromJsonElement(Signal.Hello.serializer(), json)
+        }
+    }
+    
+    return hello
+}
+
+
+/**
+ * 检测 [Signal.Hello] 是否成功。
+ */
+private fun Signal.Hello.check(): Signal.Hello {
+    if (d.code != Signal.Hello.SUCCESS_CODE) {
+        val info = Signal.Hello.getErrorInfo(d.code)
+        throw KookApiException(d.code.toInt(), info)
+    }
+    
+    return this
+}
+
+
+internal class ReconnectException(code: Int, message: String, cause: Throwable? = null) :
+    KookApiException(code, message, cause)
+
+
+/*
     
     
     /**
@@ -226,7 +899,7 @@ internal class KookBotImpl(
     private suspend fun createSession(gateway: Gateway, connectTimeout: Long): SessionInfo {
         val sn = AtomicLong(0)
         
-        val session = wsClient.ws(gateway)
+        val session = wsClient.ws(gateway.info())
         
         kotlin.runCatching {
             val timeoutJob = launch {
@@ -244,7 +917,7 @@ internal class KookBotImpl(
             val heartbeatJob = session.heartbeatJob(sn)
             
             
-            return SessionInfo(session, sn, heartbeatJob, hello)
+            return SessionInfo(session, sn, heartbeatJob.job, hello)
         }.getOrElse {
             session.closeReason.await().err(it)
         }
@@ -293,7 +966,7 @@ internal class KookBotImpl(
         // val processJob = SupervisorJob(sessionInfo.session.coroutineContext[Job])
         
         clientLogger.debug("Start processing events. isEventProcessAsync={}", isEventProcessAsync)
-    
+        
         return sessionInfo.session.incoming.receiveAsFlow().mapNotNull {
             when (it) {
                 is Frame.Text -> {
@@ -393,178 +1066,4 @@ internal class KookBotImpl(
             )
         }.launchIn(this)
     }
-    
-    
-    /**
-     * 通过 [Gateway] 连接bot信息。
-     */
-    private suspend fun HttpClient.ws(gateway: Gateway): DefaultClientWebSocketSession {
-        return webSocketSession {
-            url(gateway.url)
-        }
-    }
-    
-    
-    private suspend inline fun DefaultClientWebSocketSession.waitHello(): Signal.Hello {
-        // receive Hello
-        var hello: Signal.Hello? = null
-        while (isActive) {
-            val h = waitForHello(decoder, incoming.receive())
-            if (h != null) {
-                hello = h
-                break
-            }
-        }
-        if (hello == null) {
-            closeReason.await().err()
-        }
-        return hello
-    }
-    
-    
-    private suspend inline fun DefaultClientWebSocketSession.heartbeatJob(sn: AtomicLong): Job {
-        val heartbeatInterval = 30
-        val helloIntervalFactory: () -> Long = {
-            val r = kotlin.random.Random.nextLong(5000)
-            if (kotlin.random.Random.nextBoolean()) heartbeatInterval + r else heartbeatInterval - r
-        }
-        
-        // heartbeat Job
-        val heartbeatJob = launch {
-            val serializer = Signal.Ping.serializer()
-            while (isActive) {
-                delay(helloIntervalFactory())
-                val hb = Signal.Ping(sn.get())
-                send(decoder.encodeToString(serializer, hb))
-            }
-        }
-        
-        return heartbeatJob
-    }
-    
-    override suspend fun join() {
-        job.join()
-    }
-    
-    override suspend fun cancel(reason: Throwable?) {
-        if (job.isCancelled) {
-            return
-        }
-        
-        if (reason == null) {
-            job.cancel()
-        } else {
-            job.cancel(reason.localizedMessage, reason)
-        }
-        
-        job.join()
-    }
-    
-    private inner class ClientImpl(
-        // private val job: Job,
-        override val url: String,
-        private val sessionData: Signal.Hello,
-        private val _sn: AtomicLong,
-        private var session: DefaultClientWebSocketSession,
-    ) : KookBot.Client {
-        override val sn: Long get() = _sn.get()
-        
-        override val isActive: Boolean get() = session.isActive
-        // override val isResuming: Boolean get() = _resuming.get()
-        
-        override val bot: KookBot
-            get() = this@KookBotImpl
-        
-        override val isCompress: Boolean
-            get() = this@KookBotImpl.isCompress
-        
-        
-        suspend fun cancel(reason: Throwable? = null) {
-            val cancel = reason?.let { CancellationException(it.localizedMessage, it) }
-            
-            val sessionJob = session.coroutineContext[Job]!!
-            sessionJob.cancel(cancel)
-            sessionJob.join()
-        }
-        
-        override fun toString(): String {
-            return "Client(url=$url, sn=$sn, sessionId=${sessionData.d.sessionId})"
-        }
-        
-    }
-    
-    
-    override suspend fun me(): Me {
-        return MeRequest.requestDataBy(this)
-    }
-    
-    override suspend fun offline() {
-        return OfflineRequest.requestDataBy(this)
-    }
-    
-    
-    companion object
-    
-}
-
-
-private data class SessionInfo(
-    val session: DefaultClientWebSocketSession,
-    val sn: AtomicLong,
-    val heartbeatJob: Job,
-    val sessionData: Signal.Hello,
-)
-
-/**
- * 将 [Frame.Text] 读取为文字字符串。
  */
-private fun Frame.Text.readToText(): String {
-    return readText()
-}
-
-/**
- * 将 [Frame.Binary] 读取为文字字符串。
- */
-private fun Frame.Binary.readToText(): String {
-    return InflaterInputStream(readBytes().inputStream()).bufferedReader().use { it.readText() }
-}
-
-private fun Frame.readToText(): String {
-    return when (this) {
-        is Frame.Text -> readToText()
-        is Frame.Binary -> readToText()
-        else -> throw SimbotIllegalArgumentException("Frame is not text or binary type.")
-    }
-}
-
-
-private fun waitForHello(decoder: Json, frame: Frame): Signal.Hello? {
-    var hello: Signal.Hello? = null
-    // for hello
-    
-    if (frame is Frame.Text || frame is Frame.Binary) {
-        val json = decoder.parseToJsonElement(frame.readToText())
-        if (json.jsonObject["s"]?.jsonPrimitive?.intOrNull == Signal.Hello.S_CODE) {
-            hello = decoder.decodeFromJsonElement(Signal.Hello.serializer(), json)
-        }
-    }
-    
-    return hello
-}
-
-
-/**
- * 检测 [Signal.Hello] 是否成功。
- */
-private fun Signal.Hello.check(): Signal.Hello {
-    if (d.code != Signal.Hello.SUCCESS_CODE) {
-        val info = Signal.Hello.getErrorInfo(d.code)
-        throw KookApiException(d.code.toInt(), info)
-    }
-    
-    return this
-}
-
-
-internal class ReconnectException(code: Int, message: String, cause: Throwable? = null) :
-    KookApiException(code, message, cause)


### PR DESCRIPTION
尝试修复 #62 的问题。

问题主要产生在使用**阻塞API**时，表现为事件调度流程卡死无法处理新事件。修复前可以通过快速发送消息来复现问题，修复后暂未再次复现此问题。