### PR TITLE
优化消息链解析

### DIFF
--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/message/MessageEvents.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/message/MessageEvents.kt
@@ -39,6 +39,10 @@ public interface MessageEventExtra : Event.Extra.Text
 /**
  * 与资源相关的extra.
  *
+ * @see ImageEventExtra
+ * @see FileEventExtra
+ * @see VideoEventExtra
+ *
  */
 public interface AttachmentsMessageEventExtra<A : Attachments> : MessageEventExtra {
     public val attachments: A

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
@@ -171,7 +171,7 @@ private suspend fun Message.Element<*>.elementToRequestOrNull(
             // KMarkdown
             is KookKMarkdownMessage -> request(MessageType.KMARKDOWN.type, kMarkdown.rawContent)
             // card message
-            is KookCardMessage -> request(MessageType.CARD.type, cards.decode())
+            is KookCardMessage -> request(MessageType.CARD.type, cards.encode())
             
             // request message
             is KookRequestMessage -> this.request

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
@@ -285,7 +285,7 @@ private suspend inline fun Message.Element<*>.elementToRequest(
             // KMarkdown
             is KookKMarkdownMessage -> doRequest(MessageType.KMARKDOWN.type, message.kMarkdown.rawContent)
             // card message
-            is KookCardMessage -> doRequest(MessageType.CARD.type, message.cards.decode())
+            is KookCardMessage -> doRequest(MessageType.CARD.type, message.cards.encode())
             
             // is KookRequestMessage -> {
             //     this.request

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
@@ -21,15 +21,18 @@ import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
 import love.forte.simbot.component.kook.KookComponentBot
 import love.forte.simbot.component.kook.message.KookAttachmentMessage.Key.asMessage
-import love.forte.simbot.component.kook.message.KookKMarkdownMessage.Key.asMessage
 import love.forte.simbot.component.kook.message.KookMessages.AT_TYPE_ROLE
 import love.forte.simbot.component.kook.message.KookMessages.AT_TYPE_USER
 import love.forte.simbot.component.kook.util.requestDataBy
+import love.forte.simbot.component.kook.util.walk
 import love.forte.simbot.kook.api.message.DirectMessageDeleteRequest
 import love.forte.simbot.kook.api.message.MessageDeleteRequest
 import love.forte.simbot.kook.event.Event
 import love.forte.simbot.kook.event.message.*
+import love.forte.simbot.kook.objects.CardMessage
 import love.forte.simbot.literal
+import love.forte.simbot.logger.Logger
+import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.message.*
 import kotlin.experimental.and
 import kotlin.experimental.or
@@ -60,21 +63,21 @@ public class KookReceiveMessageContent(
      */
     public val sourceEvent: Event<Event.Extra.Text> get() = source
     
+    /**
+     * 得到消息的原始正文信息。同 `sourceEvent.content`。
+     *
+     * @see sourceEvent
+     * @see Event.content
+     */
+    public val rawContent: String get() = source.content
     
-    // TODO 描述更新
     /**
      * Kook 消息事件中所收到的消息列表。
      *
-     * 当 [source] 中的 [extra][Event.extra] 属于 [KMarkdownEventExtra] 时，
-     * messages 会至少包含两个部分：
-     * 1. 会将这个 [KMarkdownEventExtra] 直接作为 [KookKMarkdownMessage] 置于消息链首。
-     * 2. 会将 [Event.content] 作为 [Text] 进行追加，并且会根据当前消息进行**处理**。
-     * 3. 其他消息元素解析。
-     *
-     * 这会在后续详细说明。
+     * messages 会对接收到的事件中的内容进行解析，并转化为各符合内容的消息链。
      *
      * ## [Event.content] 的处理
-     * 如上所述，[Event.content] 被追加的时候会进行 **处理**。
+     * 当 [Event.extra] 为 [KMarkdownEventExtra] 类型时，[Event.content] 被追加的时候会进行 **处理**。
      * 所谓处理，就是指根据 [Event.Extra.Text] 中的 [mention][Event.Extra.Text.mention]、
      * [mentionRoles][Event.Extra.Text.mentionRoles]、[isMentionAll][Event.Extra.Text.isMentionAll]、
      * [isMentionHere][Event.Extra.Text.isMentionHere] 的信息，根据各信息出现数量依次移除 [Event.content]
@@ -87,14 +90,19 @@ public class KookReceiveMessageContent(
      *
      * 则 [Event.content] 的实际内容为：
      * ```
-     * (met)xxxx(met) hello
+     * (met)123456(met) hello
      * ```
      *
-     * 而由于 [Event.Extra.Text.mention] 出现过一次上述的 `xxxx` 的信息，因此依次移除掉一个 `(met)xxxx(met)`。
+     * 而由于 [Event.Extra.Text.mention] 出现过一次上述的 `123456` 的信息，因此依次移除掉一个 `(met)123456(met)`，而最终的 [plainText] 结果则为：
      *
-     * 如果你希望能够得到最原始的 [Event.content]，那么请通过事件对象获取而不是 [KookReceiveMessageContent]。
+     * ```
+     *  hello
+     * ```
      *
+     * 需要注意的是，这种处理不会移除或清理任何的空字符，所以你可能会发现上面处理结束后的 ` hello` 前是有一个空格的。
      *
+     * 如果你希望能够得到最原始的 [Event.content]，那么请通过 [原始事件对象][sourceEvent] 或 [rawContent] 获取，
+     * 而不是通过 [KookReceiveMessageContent.plainText] 或 [messages] 中的 [PlainText] 集。
      *
      * ```kotlin
      * val event: KookMessageEvent = ... // 一个Kook的消息事件
@@ -102,24 +110,11 @@ public class KookReceiveMessageContent(
      * // ...
      * ```
      *
-     * ## 元素冗余
-     * 还是如上所述，你会发现 [messages] 会提供一些额外的冗余消息来保证消息链中的信息绝对完整，
-     * 比如如果 [extra][Event.extra] 属于 [KMarkdownEventExtra] 类型，则会在消息链首追加一个
-     * [KookKMarkdownMessage]。而这时，消息链首已经存在了一个完整的原始消息元素，而其后仍然会继续追加其他的元素拆分：
-     * 这就会导致消息链中会出现信息量为原本两倍的内容。
-     *
-     * 当你了解这件事时，你需要额外的注意：如果你希望复述此消息，你应该使用 [KookReceiveMessageContent] 而不是 [messages]；
-     * 同样的，如果你需要处理消息，那么请注意防止出现重复的处理。
-     *
-     * 有关 [Event.Extra] 类型与对应转化规则的描述请参考 [toMessages] 文档说明。
-     *
+     * ## 转化丢失
+     * 将消息转化为一个消息链（尤其是转化kmarkdown类型的消息）的过程中有可能会丢失一部分原有的格式。因此当你直接通过 [messages] 重复发送消息时有可能会产生与收到的消息不一致的效果。
      *
      */
-    override val messages: Messages = source.toMessages()
-    
-    // TODO -> 内容转化：移除部分冗余文本
-    override val plainText: String
-        get() = super.plainText
+    override val messages: Messages by lazy(LazyThreadSafetyMode.PUBLICATION) { source.toMessages() }
     
     /**
      * 通过 [MessageDeleteRequest] 删除当前消息。
@@ -141,13 +136,10 @@ public class KookReceiveMessageContent(
     
 }
 
+private val logger = LoggerFactory.getLogger("love.forte.simbot.component.kook.message.ReceiveMessageContent")
 
 /**
  * 将消息事件相关内容转化为 [Messages].
- *
- * ## 元素冗余
- * 将文本事件转化为 [Messages] 时可能会出现消息冗余。
- * 下述为对于各 [Event.Extra] 类型的转化规则表。
  *
  * | [Event.Extra] | 转化规则 |
  * | --- | --- |
@@ -156,7 +148,7 @@ public class KookReceiveMessageContent(
  * | [FileEventExtra] | 将 [FileEventExtra.attachments] 转化为 [KookAttachmentMessage] |
  * | [VideoEventExtra] | 将 [VideoEventExtra.attachments] 转化为 [KookAttachmentMessage] |
  * | [CardEventExtra] | 将 [Event.content] 转化为 [Text] |
- * | [KMarkdownEventExtra] | 将 [KMarkdownEventExtra] 自身作为 [KookKMarkdownMessage] 添加在链首；<br /> 追加 [Event.content] 转化的 [Text]；<br /> 追加其他由 [mention][Event.Extra.Text.mention]、[mentionRoles][Event.Extra.Text.mentionRoles]、[isMentionAll][Event.Extra.Text.isMentionAll]、[isMentionHere][Event.Extra.Text.isMentionHere] 等信息而解析出来的 [At]、[AtAll]、[KookAtAllHere] 等信息。其中，[AtAll]、[KookAtAllHere] 至多只会各自出现一次。 |
+ * | [KMarkdownEventExtra] | 将 [Event.content] 转化为 [Text]（会对特殊内容进行适当的移除）；<br /> 追加其他由 [mention][Event.Extra.Text.mention]、[mentionRoles][Event.Extra.Text.mentionRoles]、[isMentionAll][Event.Extra.Text.isMentionAll]、[isMentionHere][Event.Extra.Text.isMentionHere] 等信息而解析出来的 [At]、[AtAll]、[KookAtAllHere] 等信息。其中，[AtAll]、[KookAtAllHere] 至多只会各自出现一次。 |
  * | 其他 | 将 [Event.content] 转化为 [Text] |
  *
  */
@@ -166,27 +158,18 @@ public fun Event<Event.Extra.Text>.toMessages(): Messages {
             extra.toMessages { listOf(content.toText()) }
         }
         
-        is ImageEventExtra -> {
-            extra.toMessages { listOf(extra.attachments.asMessage()) }
-        }
-        
-        is FileEventExtra -> {
-            extra.toMessages { listOf(extra.attachments.asMessage()) }
-        }
-        
-        is VideoEventExtra -> {
+        // ImageEventExtra, FileEventExtra,VideoEventExtra
+        is AttachmentsMessageEventExtra<*> -> {
             extra.toMessages { listOf(extra.attachments.asMessage()) }
         }
         
         is KMarkdownEventExtra -> {
-            @OptIn(ExperimentalSimbotApi::class)
-            extra.toMessages {
-                listOf(extra.kmarkdown.asMessage(), content.toTextResolvedByTextEvent(extra))
-            }
+            toMessagesByKMarkdown(content, extra.mention, extra.mentionRoles, extra.isMentionAll, extra.isMentionHere)
         }
         
         is CardEventExtra -> {
-            extra.toMessages { listOf(content.toText()) }
+            // try decode
+            extra.toMessages { tryDecodeCardContent(content, logger) }
         }
         
         else -> {
@@ -194,11 +177,6 @@ public fun Event<Event.Extra.Text>.toMessages(): Messages {
         }
     }
 }
-
-public fun toMessages(type: Int, ) {
-
-}
-
 
 private inline fun Event.Extra.Text.toMessages(contentElement: () -> List<Message.Element<*>>): Messages {
     return toMessages(
@@ -213,6 +191,20 @@ private inline fun Event.Extra.Text.toMessages(contentElement: () -> List<Messag
 public fun Event<Event.Extra.Text>.toContent(isDirect: Boolean, bot: KookComponentBot): KookReceiveMessageContent =
     KookReceiveMessageContent(isDirect, this, bot)
 
+@OptIn(ExperimentalSimbotApi::class)
+internal fun tryDecodeCardContent(content: String, logger: Logger): List<Message.Element<*>> {
+    return runCatching {
+        listOf(KookCardMessage(CardMessage.decode(content)))
+    }.getOrElse { ex ->
+        if (logger.isDebugEnabled) {
+            logger.debug("Cannot decode card message content [{}] to CardMessage, as text.", content, ex)
+        } else {
+            logger.warn("Cannot decode card message content to CardMessage, as text.", ex)
+        }
+        listOf(content.toText())
+    }
+}
+
 private const val MET_NAME = "metId"
 private const val ROL_NAME = "rolId"
 private const val MET_REGEX_VALUE = "\\(met\\)(?<$MET_NAME>([a-zA-Z\\d]+|here|all))\\(met\\)"
@@ -221,134 +213,17 @@ private const val ROL_REGEX_VALUE = "\\(rol\\)(?<$ROL_NAME>[a-zA-Z\\d]+)\\(rol\\
 private val matchRegex = Regex("($MET_REGEX_VALUE)|($ROL_REGEX_VALUE)")
 
 
-internal data class MentionCount(val id: String, var count: Int)
+internal data class MentionCount(val id: ID, var count: Int)
 
 internal fun Collection<ID>.toMentionCount(): MutableMap<String, MentionCount> {
     val map = mutableMapOf<String, MentionCount>()
     this.forEach { id ->
         val idValue = id.literal
-        map.compute(idValue) { k, current ->
-            current?.also { it.count++ } ?: MentionCount(k, 1)
+        map.compute(idValue) { _, current ->
+            current?.also { it.count++ } ?: MentionCount(id, 1)
         }
     }
     return map
-}
-
-/**
- *
- * 处理目标：
- * - `(met)用户id/here/all(met)`: @用户，all 代表 @所有用户，here 代表 @所有在线用户
- * - `(rol)角色ID(rol)`: @某角色所有用户
- *
- */
-internal fun String.toTextResolvedByTextEvent(event: Event.Extra.Text): Text {
-    val metAll = event.isMentionAll
-    val metHere = event.isMentionHere
-    val metMap = event.mention.toMentionCount()
-    val metRoleMap = event.mentionRoles.toMentionCount()
-    
-    return toTextResolvedByTextEvent(metAll, metHere, metMap, metRoleMap)
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun String.toTextResolvedByTextEvent(
-    metAll0: Boolean,
-    metHere0: Boolean,
-    metMap: MutableMap<String, MentionCount>,
-    metRoleList: MutableMap<String, MentionCount>,
-): Text {
-    var metAll = metAll0
-    var metHere = metHere0
-    
-    val zeroMark: Byte = 0
-    var status: Byte = 0
-    if (metAll) {
-        status = status or 0b1000
-    }
-    if (metHere) {
-        status = status or 0b0100
-    }
-    if (metMap.isNotEmpty()) {
-        status = status or 0b0010
-    }
-    if (metRoleList.isNotEmpty()) {
-        status = status or 0b0001
-    }
-    
-    if (status == zeroMark) {
-        return toText()
-    }
-    
-    val result = matchRegex.replace(this) { result ->
-        if (status == zeroMark) {
-            return@replace result.value
-        }
-        
-        if (status and 0b1110 > 0) {
-            val metId = result.groups[MET_NAME]
-            if (metId != null) {
-                val id = metId.value
-                when {
-                    metAll && id == "all" -> {
-                        metAll = false
-                        status = status and 0b0111
-                        return@replace ""
-                    }
-                    
-                    metHere && id == "here" -> {
-                        metHere = false
-                        status = status and 0b1011
-                        return@replace ""
-                    }
-                    
-                    else -> {
-                        if (metMap.isEmpty()) {
-                            status = status and 0b1101
-                        } else {
-                            val met = metMap[id]
-                            if (met != null) {
-                                met.count--
-                                if (met.count <= 0) {
-                                    metMap.remove(id)
-                                }
-                                // the id, try remove.
-                                return@replace ""
-                            }
-                        }
-                    }
-                }
-                // end.
-                return@replace result.value
-            }
-        }
-        
-        
-        if (status and 0b0001 > 0) {
-            val roleId = result.groups[ROL_NAME]
-            if (roleId != null) {
-                val id = roleId.value
-                if (metRoleList.isEmpty()) {
-                    status = status and 0b1110
-                } else {
-                    val met = metRoleList[id]
-                    if (met != null) {
-                        met.count--
-                        if (met.count <= 0) {
-                            metRoleList.remove(id)
-                        }
-                        // the id, try remove.
-                        return@replace ""
-                    }
-                }
-                return@replace result.value
-            }
-        }
-        
-        
-        result.value
-    }
-    
-    return result.toText()
 }
 
 internal fun toMessages(
@@ -380,6 +255,149 @@ internal fun toMessages(
     }
     
     return messages.toMessages()
+}
+
+internal fun toMessagesByKMarkdown(
+    content: String,
+    mention: Collection<ID>, mentionRoles: Collection<ID>,
+    isMentionAll: Boolean, isMentionHere: Boolean,
+): Messages {
+    if (mention.isEmpty() && mentionRoles.isEmpty() && !isMentionAll && !isMentionHere) {
+        return content.toText().toMessages()
+    }
+    
+    var metAll = isMentionAll
+    var metHere = isMentionHere
+    val metMap = mention.toMentionCount()
+    val metRoleMap = mentionRoles.toMentionCount()
+    
+    val zeroMark: Byte = 0
+    var status: Byte = 0
+    if (metAll) {
+        status = status or 0b1000
+    }
+    if (metHere) {
+        status = status or 0b0100
+    }
+    if (metMap.isNotEmpty()) {
+        status = status or 0b0010
+    }
+    if (metRoleMap.isNotEmpty()) {
+        status = status or 0b0001
+    }
+    
+    return buildMessages {
+        var textBuffer: StringBuilder? = StringBuilder()
+        fun addText(value: CharSequence, start: Int, end: Int) {
+            val tb = textBuffer ?: StringBuilder().also { textBuffer = it }
+            tb.append(value, start, end)
+        }
+        
+        fun addText(value: String) {
+            val tb = textBuffer ?: StringBuilder().also { textBuffer = it }
+            tb.append(value)
+        }
+        
+        fun addElement(element: Message.Element<*>) {
+            val tb = textBuffer?.toString()
+            if (tb?.isNotEmpty() == true) {
+                text(tb)
+                textBuffer = null
+            }
+            
+            +element
+        }
+        
+        fun clearBuffer() {
+            textBuffer?.toString()?.takeIf { it.isNotEmpty() }?.let { t ->
+                text(t)
+            }
+        }
+        
+        val matched = matchRegex.walk(content, { c, s, e ->
+            addText(c, s, e)
+        }) { result ->
+            if (status == zeroMark) {
+                addText(result.value)
+            }
+            
+            if (status and 0b1110 > 0) {
+                val metId = result.groups[MET_NAME]
+                if (metId != null) {
+                    val id = metId.value
+                    var skipText = false
+                    when {
+                        metAll && id == "all" -> {
+                            metAll = false
+                            status = status and 0b0111
+                            addElement(AtAll)
+                            skipText = true
+                        }
+                        
+                        metHere && id == "here" -> {
+                            metHere = false
+                            status = status and 0b1011
+                            addElement(KookAtAllHere)
+                            skipText = true
+                        }
+                        
+                        else -> {
+                            if (metMap.isEmpty()) {
+                                status = status and 0b1101
+                            } else {
+                                val met = metMap[id]
+                                if (met != null) {
+                                    met.count--
+                                    if (met.count <= 0) {
+                                        metMap.remove(id)
+                                    }
+                                    // mention user
+                                    addElement(At(met.id, type = AT_TYPE_USER))
+                                    skipText = true
+                                }
+                            }
+                        }
+                    }
+                    // end.
+                    if (!skipText) {
+                        addText(result.value)
+                    }
+                }
+            }
+            
+            
+            if (status and 0b0001 > 0) {
+                val roleId = result.groups[ROL_NAME]
+                if (roleId != null) {
+                    var skipText = false
+                    val id = roleId.value
+                    if (metRoleMap.isEmpty()) {
+                        status = status and 0b1110
+                    } else {
+                        val met = metRoleMap[id]
+                        if (met != null) {
+                            met.count--
+                            if (met.count <= 0) {
+                                metRoleMap.remove(id)
+                            }
+                            // mention role
+                            addElement(At(met.id, type = AT_TYPE_ROLE))
+                            skipText = true
+                        }
+                    }
+                    if (!skipText) {
+                        addText(result.value)
+                    }
+                }
+            }
+        }
+        
+        if (!matched) {
+            addText(content)
+        }
+        
+        clearBuffer()
+    }
 }
 
 

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/util/RegexWalker.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/util/RegexWalker.kt
@@ -1,0 +1,24 @@
+package love.forte.simbot.component.kook.util
+
+/**
+ * @return true if find([input]) != null
+ */
+public inline fun Regex.walk(input: String, onOther: (input: String, start: Int, end: Int) -> Unit, onMatch: (MatchResult) -> Unit): Boolean {
+    var match: MatchResult? = find(input) ?: return false
+    
+    var lastStart = 0
+    val length = input.length
+    do {
+        val foundMatch = match!!
+        onOther(input, lastStart, foundMatch.range.first)
+        onMatch(foundMatch)
+        lastStart = foundMatch.range.last + 1
+        match = foundMatch.next()
+    } while (lastStart < length && match != null)
+    
+    if (lastStart < length) {
+        onOther(input, lastStart, length)
+    }
+    
+    return true
+}


### PR DESCRIPTION
现在对于消息链的解析：
- 不再有首部冗余的 `KookKMarkdownMessage` 了
- 消息链的顺序与内容更加正确
- 消息链中的纯文本信息（包括 `plainText`）会尝试移除多余的 KMarkdown mention 语法
