### PR TITLE
将所有API的构造方式调整为通过 `create(...)` 工厂函数提供

### DIFF
--- a/simbot-component-kook-api/build.gradle.kts
+++ b/simbot-component-kook-api/build.gradle.kts
@@ -26,7 +26,6 @@ plugins {
 dependencies {
     api(simbotApi)
     api(simbotRequestorCore)
-    api(simbotRequestorKtor)
     api(kotlin("reflect"))
 
     api(libs.ktor.client.core)

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/ApiRateLimit.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/ApiRateLimit.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.kook.api
 
 import io.ktor.client.statement.*
+import io.ktor.http.*
 
 
 // TODO
@@ -71,27 +72,54 @@ public object ApiRateLimits {
 /**
  * 尝试获取 [HttpResponse] 中的 [ApiRateLimits.RATE_LIMIT_LIMIT_HEAD] 信息。
  */
-public val HttpResponse.rateLimit: Int? get() = headers[ApiRateLimits.RATE_LIMIT_LIMIT_HEAD]?.toIntOrNull()
+public inline val HttpResponse.rateLimit: Long? get() = headers.rateLimit
 
 /**
  * 尝试获取 [HttpResponse] 中的 [ApiRateLimits.RATE_LIMIT_REMAINING_HEAD] 信息。
  */
-public val HttpResponse.rateRemaining: Int? get() = headers[ApiRateLimits.RATE_LIMIT_REMAINING_HEAD]?.toIntOrNull()
+public inline val HttpResponse.rateRemaining: Long? get() = headers.rateRemaining
 
 /**
  * 尝试获取 [HttpResponse] 中的 [ApiRateLimits.RATE_LIMIT_RESET_HEAD] 信息。
  */
-public val HttpResponse.rateReset: Int? get() = headers[ApiRateLimits.RATE_LIMIT_RESET_HEAD]?.toIntOrNull()
+public inline val HttpResponse.rateReset: Long? get() = headers.rateReset
 
 /**
  * 尝试获取 [HttpResponse] 中的 [ApiRateLimits.RATE_LIMIT_BUCKET_HEAD] 信息。
  */
-public val HttpResponse.rateBucket: String? get() = headers[ApiRateLimits.RATE_LIMIT_BUCKET_HEAD]
+public inline val HttpResponse.rateBucket: String? get() = headers.rateBucket
 
 /**
  * [HttpResponse] 中是否存在 [ApiRateLimits.RATE_LIMIT_GLOBAL_HEAD]。
  */
-public val HttpResponse.isRateGlobal: Boolean get() = headers[ApiRateLimits.RATE_LIMIT_GLOBAL_HEAD] != null
+public inline val HttpResponse.isRateGlobal: Boolean get() = headers.isRateGlobal
+
+
+
+/**
+ * 尝试获取 [Headers] 中的 [ApiRateLimits.RATE_LIMIT_LIMIT_HEAD] 信息。
+ */
+public inline val Headers.rateLimit: Long? get() = this[ApiRateLimits.RATE_LIMIT_LIMIT_HEAD]?.toLongOrNull()
+
+/**
+ * 尝试获取 [Headers] 中的 [ApiRateLimits.RATE_LIMIT_REMAINING_HEAD] 信息。
+ */
+public inline val Headers.rateRemaining: Long? get() = this[ApiRateLimits.RATE_LIMIT_REMAINING_HEAD]?.toLongOrNull()
+
+/**
+ * 尝试获取 [Headers] 中的 [ApiRateLimits.RATE_LIMIT_RESET_HEAD] 信息。
+ */
+public inline val Headers.rateReset: Long? get() = this[ApiRateLimits.RATE_LIMIT_RESET_HEAD]?.toLongOrNull()
+
+/**
+ * 尝试获取 [Headers] 中的 [ApiRateLimits.RATE_LIMIT_BUCKET_HEAD] 信息。
+ */
+public inline val Headers.rateBucket: String? get() = this[ApiRateLimits.RATE_LIMIT_BUCKET_HEAD]
+
+/**
+ * [Headers] 中是否存在 [ApiRateLimits.RATE_LIMIT_GLOBAL_HEAD]。
+ */
+public inline val Headers.isRateGlobal: Boolean get() = this[ApiRateLimits.RATE_LIMIT_GLOBAL_HEAD] != null
 
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/GatewayRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/GatewayRequest.kt
@@ -36,8 +36,6 @@ import love.forte.simbot.kook.api.GatewayRequest.*
  * @author ForteScarlet
  */
 public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetRequest<Gateway>() {
-    public companion object Key : BaseKookApiRequestKey("gateway", "index")
-
 
     override fun ParametersBuilder.buildParameters() {
         append("compress", if (isCompress) "1" else "0")
@@ -66,7 +64,7 @@ public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetReq
     /**
      * 重连获取路由时使用的api。
      */
-    public class Resume(internal val isCompress: Boolean, private val sn: Long, private val sessionId: String) :
+    public class Resume internal constructor(internal val isCompress: Boolean, private val sn: Long, private val sessionId: String) :
         GatewayRequest(isCompress) {
         override fun ParametersBuilder.buildParameters0() {
             append("resume", "1")
@@ -74,6 +72,31 @@ public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetReq
             append("session_id", sessionId)
         }
     }
+    
+    public companion object Key : BaseKookApiRequestKey("gateway", "index") {
+    
+        /**
+         * 根据 [isCompress] 的值选择 [Compress] 或 [NotCompress].
+         * @param isCompress 是否进行数据压缩
+         * @see Compress
+         * @see NotCompress
+         */
+        @JvmStatic
+        public fun create(isCompress: Boolean): GatewayRequest {
+            return if (isCompress) Compress else NotCompress
+        }
+    
+        /**
+         * 构建一个用于重新连接的 [Resume] 实例。
+         * @see Resume
+         */
+        @JvmStatic
+        public fun create(isCompress: Boolean, sn: Long, sessionId: String): GatewayRequest {
+            return Resume(isCompress, sn, sessionId)
+        }
+        
+    }
+    
 }
 
 
@@ -81,7 +104,7 @@ public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetReq
 public fun GatewayRequest.resume(sn: Long, sessionId: String): Resume {
     return when (this) {
         is Compress -> Resume(true, sn, sessionId)
-        is NotCompress -> Resume(true, sn, sessionId)
+        is NotCompress -> Resume(false, sn, sessionId)
         is Resume -> Resume(isCompress, sn, sessionId)
     }
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/GatewayRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/GatewayRequest.kt
@@ -91,7 +91,7 @@ public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetReq
          * @see Resume
          */
         @JvmStatic
-        public fun create(isCompress: Boolean, sn: Long, sessionId: String): GatewayRequest {
+        public fun create(isCompress: Boolean, sn: Long, sessionId: String): Resume {
             return Resume(isCompress, sn, sessionId)
         }
         
@@ -99,7 +99,10 @@ public sealed class GatewayRequest(private val isCompress: Boolean) : KookGetReq
     
 }
 
-
+/**
+ * 将一个 [GatewayRequest] 根据重连参数重构为用于重新连接的 [Resume].
+ *
+ */
 @Suppress("unused")
 public fun GatewayRequest.resume(sn: Long, sessionId: String): Resume {
     return when (this) {

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
@@ -29,11 +29,6 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 import love.forte.simbot.Api4J
 import love.forte.simbot.kook.Kook
-import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_BUCKET
-import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_GLOBAL
-import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_LIMIT
-import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_REMAINING
-import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_RESET
 import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.util.api.requestor.API
 import love.forte.simbot.utils.runInNoScopeBlocking
@@ -128,11 +123,13 @@ public abstract class KookApiRequest<T> : API<KookApiRequestor, T> {
         // init rate limit info.
         val headers = response.headers
         
-        val limit = headers[X_RATE_LIMIT_LIMIT]?.toLongOrNull() // ?: RateLimit.DEFAULT.limit
-        val remaining = headers[X_RATE_LIMIT_REMAINING]?.toLongOrNull() // ?: RateLimit.DEFAULT.remaining
-        val reset = headers[X_RATE_LIMIT_RESET]?.toLongOrNull() // ?: RateLimit.DEFAULT.reset
-        val bucket = headers[X_RATE_LIMIT_BUCKET] // ?: RateLimit.DEFAULT.bucket
-        val global = headers[X_RATE_LIMIT_GLOBAL] != null
+        
+        
+        val limit = headers.rateLimit
+        val remaining = headers.rateRemaining
+        val reset = headers.rateReset
+        val bucket = headers.rateBucket
+        val global = headers.isRateGlobal
         
         val rateLimit = if (limit != null || remaining != null || reset != null || bucket != null || global) {
             RateLimit(

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
@@ -35,7 +35,8 @@ import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_LIMIT
 import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_REMAINING
 import love.forte.simbot.kook.api.RateLimit.Companion.X_RATE_LIMIT_RESET
 import love.forte.simbot.logger.LoggerFactory
-import love.forte.simbot.utils.runInBlocking
+import love.forte.simbot.util.api.requestor.API
+import love.forte.simbot.utils.runInNoScopeBlocking
 import love.forte.simbot.utils.runWithInterruptible
 import java.util.function.Consumer
 
@@ -53,46 +54,51 @@ private val logger = LoggerFactory.getLogger("KookApiRequest.debug")
  * ### 不可变
  * 此接口的实现类应当是不可变、可复用的。
  */
-public abstract class KookApiRequest<T> {
-
+public abstract class KookApiRequest<T> : API<KookApiRequestor, T> {
+    
     /**
      * 此请求最终对应的url。最终拼接的URL中部分参数（例如host）来自于 [Kook].
      */
     public abstract val url: Url
-
-
+    
+    
     /**
      * 此请求的 method.
      */
     public abstract val method: HttpMethod
-
-
+    
+    
     /**
      * 得到响应值的反序列化器.
      */
     public abstract val resultDeserializer: DeserializationStrategy<out T>
-
-
+    
+    
     /**
      * 可以为 [request] 提供更多行为的函数，例如提供body、重置contentType等。
      */
     protected open fun HttpRequestBuilder.requestFinishingAction() {
         headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
     }
-
-
+    
+    
+    @JvmSynthetic
+    override suspend fun requestBy(requestor: KookApiRequestor): T {
+        return requestData(
+            requestor.client,
+            requestor.authorization,
+            DEFAULT_JSON
+        )
+    }
+    
+    @Api4J
+    public fun requestBlockingBy(requestor: KookApiRequestor): T = runInNoScopeBlocking { requestBlockingBy(requestor) }
+    
     /**
      * 通过 [client] 执行网络请求并尝试得到结果。
      *
      * @param client 使用的 [HttpClient] 实例。
      * @param authorization 使用的鉴权值。注意，这里是完整的 `Authorization` 请求头中应当存在的内容，例如 `Bot aaaabbbbccccdddd`. 请参考 <https://developer.kaiheila.cn/doc/reference#%E5%B8%B8%E8%A7%84%20http%20%E6%8E%A5%E5%8F%A3%E8%A7%84%E8%8C%83>.
-     * @param decoder 用于反序列化的 [Json] 实例。如果不提供则使用内部的默认值:
-     * ```kotlin
-     * Json {
-     *      isLenient = true
-     *      ignoreUnknownKeys = true
-     *  }
-     * ```
      *
      * 可以通过重写 [requestFinishingAction] 来实现提供额外的收尾操作，例如为请求提供 body 等。
      *
@@ -105,30 +111,29 @@ public abstract class KookApiRequest<T> {
     public open suspend fun request(
         client: HttpClient,
         authorization: String,
-        decoder: Json = DEFAULT_JSON,
         postChecker: suspend (HttpResponse) -> Unit = {}
     ): ApiResult {
         val response = requestForResponse(client, authorization) {
             requestFinishingAction()
         }
-
+        
         postChecker(response)
-    
+        
         logger.trace("api request response.body(), response: {}", response)
         
         val result: ApiResult = response.body()
-    
+        
         logger.trace("api request result pre rate limit: {}", result)
         
         // init rate limit info.
         val headers = response.headers
-
+        
         val limit = headers[X_RATE_LIMIT_LIMIT]?.toLongOrNull() // ?: RateLimit.DEFAULT.limit
         val remaining = headers[X_RATE_LIMIT_REMAINING]?.toLongOrNull() // ?: RateLimit.DEFAULT.remaining
         val reset = headers[X_RATE_LIMIT_RESET]?.toLongOrNull() // ?: RateLimit.DEFAULT.reset
         val bucket = headers[X_RATE_LIMIT_BUCKET] // ?: RateLimit.DEFAULT.bucket
         val global = headers[X_RATE_LIMIT_GLOBAL] != null
-
+        
         val rateLimit = if (limit != null || remaining != null || reset != null || bucket != null || global) {
             RateLimit(
                 limit ?: RateLimit.DEFAULT.limit,
@@ -140,27 +145,20 @@ public abstract class KookApiRequest<T> {
         } else {
             RateLimit.DEFAULT
         }
-
+        
         result.rateLimit = rateLimit
-    
+        
         logger.trace("api request result: {}", result)
-    
+        
         return result
     }
-
-
+    
+    
     /**
      * 通过 [client] 执行网络请求并尝试得到结果。
      *
      * @param client 使用的 [HttpClient] 实例。
      * @param authorization 使用的鉴权值。注意，这里是完整的 `Authorization` 请求头中应当存在的内容，例如 `Bot aaaabbbbccccdddd`. 请参考 <https://developer.kaiheila.cn/doc/reference#%E5%B8%B8%E8%A7%84%20http%20%E6%8E%A5%E5%8F%A3%E8%A7%84%E8%8C%83>.
-     * @param decoder 用于反序列化的 [Json] 实例。如果不提供则使用内部的默认值:
-     * ```kotlin
-     * Json {
-     *      isLenient = true
-     *      ignoreUnknownKeys = true
-     *  }
-     * ```
      *
      * 可以通过重写 [requestFinishingAction] 来实现提供额外的收尾操作，例如为请求提供 body 等。
      *
@@ -175,15 +173,14 @@ public abstract class KookApiRequest<T> {
     public open fun requestBlocking(
         client: HttpClient,
         authorization: String,
-        decoder: Json = DEFAULT_JSON,
         postChecker: Consumer<HttpResponse> = defaultRequestPostChecker
-    ): ApiResult = runInBlocking {
-        request(client, authorization, decoder) { resp ->
+    ): ApiResult = runInNoScopeBlocking {
+        request(client, authorization) { resp ->
             runWithInterruptible { postChecker.accept(resp) }
         }
     }
-
-
+    
+    
     /**
      * 通过 [client] 执行网络请求并尝试得到结果。
      *
@@ -194,19 +191,22 @@ public abstract class KookApiRequest<T> {
      * Json {
      *      isLenient = true
      *      ignoreUnknownKeys = true
+     *      encodeDefaults = true
      *  }
      * ```
      *
      */
     @JvmSynthetic
     public open suspend fun requestData(
-        client: HttpClient, authorization: String, decoder: Json = DEFAULT_JSON
+        client: HttpClient,
+        authorization: String,
+        decoder: Json = DEFAULT_JSON
     ): T {
-        val result = request(client, authorization, decoder)
+        val result = request(client, authorization)
         return result.parseDataOrThrow(decoder, resultDeserializer)
     }
-
-
+    
+    
     /**
      * 通过 [client] 执行网络请求并尝试得到结果。
      *
@@ -225,18 +225,19 @@ public abstract class KookApiRequest<T> {
     @JvmOverloads
     public open fun requestDataBlocking(
         client: HttpClient, authorization: String, decoder: Json = DEFAULT_JSON
-    ): T = runInBlocking { requestData(client, authorization, decoder) }
-
-
+    ): T = runInNoScopeBlocking { requestData(client, authorization, decoder) }
+    
+    
     public companion object {
         internal val DEFAULT_JSON = Json {
             isLenient = true
             ignoreUnknownKeys = true
+            encodeDefaults = true
         }
-
+        
         internal val defaultRequestPostChecker: Consumer<HttpResponse> = Consumer {}
     }
-
+    
 }
 
 /**
@@ -249,12 +250,12 @@ private suspend inline fun KookApiRequest<*>.requestForResponse(
 ): HttpResponse {
     return client.request {
         this.method = this@requestForResponse.method
-
+        
         // set url
         url(this@requestForResponse.url)
-
+        
         headers[HttpHeaders.Authorization] = authorization
-
+        
         // 收尾动作
         finishingAction()
     }
@@ -266,14 +267,14 @@ public abstract class BaseKookApiRequest<T> : KookApiRequest<T>() {
      * api 路径。
      */
     protected abstract val apiPaths: List<String>
-
+    
     /**
      * 参数构建器。
      */
     protected open fun ParametersBuilder.buildParameters() {}
-
+    
     private lateinit var _url: Url
-
+    
     /**
      * 通过 [apiPaths] 和 [buildParameters] 懒构建 [url] 属性。
      */
@@ -288,7 +289,7 @@ public abstract class BaseKookApiRequest<T> : KookApiRequest<T>() {
                 buildUrl.also { _url = it }
             }
         }
-
+    
 }
 
 
@@ -315,10 +316,10 @@ public abstract class KookPostRequest<T>(
 ) : BaseKookApiRequest<T>() {
     override val method: HttpMethod
         get() = HttpMethod.Post
-
+    
     private lateinit var _body: Any
-
-
+    
+    
     /**
      * 可以提供一个body实例。
      */
@@ -342,15 +343,15 @@ public abstract class KookPostRequest<T>(
                         }
                     }
                 }
-
+                
             } else createBody()
         }
-
+    
     /**
      * 构建一个新的 [body] 所使用的函数。用于简化懒加载逻辑。
      */
     protected open fun createBody(): Any? = null
-
+    
     /**
      * 通过 [body] 构建提供 body 属性。
      */
@@ -358,8 +359,8 @@ public abstract class KookPostRequest<T>(
         headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
         setBody(this@KookPostRequest.body ?: EmptyContent)
     }
-
-
+    
+    
     private object NULL
 }
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequestor.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequestor.kt
@@ -1,0 +1,23 @@
+package love.forte.simbot.kook.api
+
+import io.ktor.client.*
+import love.forte.simbot.util.api.requestor.Requestor
+
+
+/**
+ * 用于提供给 [KookApiRequest] 作为请求器使用。
+ * @author ForteScarlet
+ */
+public interface KookApiRequestor : Requestor {
+    /**
+     * 用于进行请求的 [HttpClient]
+     */
+    public val client: HttpClient
+    
+    /**
+     * 使用的鉴权值。
+     * 注意，这里是完整的 `Authorization` 请求头中应当存在的内容，
+     * 例如 `Bot aaaabbbbccccdddd`
+     */
+    public val authorization: String
+}

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiResult.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiResult.kt
@@ -238,11 +238,11 @@ public data class RateLimit(
 
     ) {
     public companion object {
-        public const val X_RATE_LIMIT_LIMIT: String = "X-Rate-Limit-Limit"
-        public const val X_RATE_LIMIT_REMAINING: String = "X-Rate-Limit-Remaining"
-        public const val X_RATE_LIMIT_RESET: String = "X-Rate-Limit-Reset"
-        public const val X_RATE_LIMIT_BUCKET: String = "X-Rate-Limit-Bucket"
-        public const val X_RATE_LIMIT_GLOBAL: String = "X-Rate-Limit-Global"
+        public const val X_RATE_LIMIT_LIMIT: String = ApiRateLimits.RATE_LIMIT_LIMIT_HEAD // "X-Rate-Limit-Limit"
+        public const val X_RATE_LIMIT_REMAINING: String = ApiRateLimits.RATE_LIMIT_REMAINING_HEAD // "X-Rate-Limit-Remaining"
+        public const val X_RATE_LIMIT_RESET: String = ApiRateLimits.RATE_LIMIT_RESET_HEAD // "X-Rate-Limit-Reset"
+        public const val X_RATE_LIMIT_BUCKET: String = ApiRateLimits.RATE_LIMIT_BUCKET_HEAD // "X-Rate-Limit-Bucket"
+        public const val X_RATE_LIMIT_GLOBAL: String = ApiRateLimits.RATE_LIMIT_GLOBAL_HEAD // "X-Rate-Limit-Global"
 
         public val DEFAULT: RateLimit = RateLimit(99999, 99999, 0, "default/not-init", false)
     }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/asset/AssetCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/asset/AssetCreateRequest.kt
@@ -36,29 +36,43 @@ import java.net.URL
 
 
 /**
- *
  * [上传媒体文件](https://developer.kaiheila.cn/doc/http/asset).
  *
  * 创建（上传）文件资源，例如图片等。
  *
  *
- * @param resource 资源对象。
- * @param name 需要能够体现出文件的扩展名（例如 `mov`, `jpg`），否则尽可能提供 `resourceContentType` 参数。
- * @param resourceContentType 资源的content类型。
  * @author ForteScarlet
  */
-public class AssetCreateRequest(
+public class AssetCreateRequest internal constructor(
     private val resource: Resource,
     private val name: String? = resource.name,
     resourceContentType: ContentType? = null
 ) : KookPostRequest<AssetCreated>(false) {
     public companion object Key : BaseKookApiRequestKey("asset", "create") {
         private val logger = LoggerFactory.getLogger("love.forte.simbot.kook.api.asset.AssetCreateRequest")
+        
+        /**
+         * 构造一个 [AssetCreateRequest].
+         *
+         * @param resource 资源对象。
+         * @param name 需要能够体现出文件的扩展名（例如 `mov`, `jpg`），否则尽可能提供 `resourceContentType` 参数。
+         * @param resourceContentType 资源的content类型。
+         
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            resource: Resource,
+            name: String? = resource.name,
+            resourceContentType: ContentType? = null
+        ): AssetCreateRequest {
+            return AssetCreateRequest(resource, name, resourceContentType)
+        }
     }
-
+    
     private val contentType: ContentType
     private val inputProvider = InputProvider { resource.openStream().asInput() }
-
+    
     init {
         contentType = resourceContentType ?: run {
             val index = name?.lastIndexOf('.') ?: -1
@@ -76,15 +90,15 @@ public class AssetCreateRequest(
                 }
             }
         }
-
-
+        
+        
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out AssetCreated>
         get() = AssetCreated.serializer()
-
+    
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun HttpRequestBuilder.requestFinishingAction() {
         setBody(this@AssetCreateRequest.body ?: EmptyContent)
         onUpload { bytesSentTotal, contentLength ->
@@ -97,17 +111,12 @@ public class AssetCreateRequest(
                 )
             }
         }
-        // headers {
-        //     //remove(HttpHeaders.ContentType)
-        //     this[HttpHeaders.ContentType] // = ContentType.Application
-        // }
     }
-
+    
     override fun createBody(): Any {
-
         return MultiPartFormDataContent(
             formData {
-
+                
                 val headers = headersOf(
                     if (name != null) {
                         HttpHeaders.ContentDisposition to listOf("filename=$name")
@@ -115,7 +124,7 @@ public class AssetCreateRequest(
                         HttpHeaders.ContentDisposition to listOf("filename=simbot-${RandomIDUtil.randomID()}")
                     }
                 )
-
+                
                 append(
                     "file",
                     inputProvider,
@@ -124,8 +133,8 @@ public class AssetCreateRequest(
             }
         )
     }
-
-
+    
+    
 }
 
 /**
@@ -133,7 +142,7 @@ public class AssetCreateRequest(
  */
 @Serializable
 public data class AssetCreated @ApiResultType constructor(val url: String) {
-
+    
     /**
      * 通过 [url] 构建一个 [URLResource].
      */

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelCreateRequest.kt
@@ -34,58 +34,86 @@ import love.forte.simbot.kook.objects.Channel
  *
  * @author ForteScarlet
  */
-public class ChannelCreateRequest @JvmOverloads constructor(
-    /** 是 服务器id */
+public class ChannelCreateRequest internal constructor(
     private val guildId: ID,
-    /** 是 频道名称 */
     private val name: String,
-    /** 否 频道类型，1 文字，2 语音，默认为文字 */
-    private val type: Int = 1,
-    /** 否 父分组id */
-    private val parentId: ID? = null,
-    /** 否 语音频道人数限制，最大99 */
-    private val limitAmount: Int = 99,
-    /** 否 语音音质，默认为2。1流畅，2正常，3高质量 */
-    private val voiceQuality: Int = 2,
+    private val type: Int,
+    private val parentId: ID?,
+    private val limitAmount: Int,
+    private val voiceQuality: Int,
 ) : KookPostRequest<Channel>() {
-    public companion object Key : BaseKookApiRequestKey("channel", "create")
-
+    @Suppress("MemberVisibilityCanBePrivate")
+    public companion object Key : BaseKookApiRequestKey("channel", "create") {
+        
+        /** 语音品质：流畅 */
+        public const val VOICE_QUALITY_SMOOTH: Int = 1
+        /** 语音品质：正常 */
+        public const val VOICE_QUALITY_NORMAL: Int = 2
+        /** 语音品质：高品质 */
+        public const val VOICE_QUALITY_HIGH: Int = 3
+        
+        
+        /**
+         * 构建 [ChannelCreateRequest].
+         * @param guildId 服务器id
+         * @param name 频道名称
+         * @param type 频道类型，1 文字，2 语音，默认为文字
+         * @param parentId 父分组id
+         * @param limitAmount 语音频道人数限制，最大99
+         * @param voiceQuality 语音音质，默认为2。
+         * - 流畅: 1（[VOICE_QUALITY_SMOOTH]）
+         * - 正常: 2（[VOICE_QUALITY_NORMAL]）
+         * - 高质量: 3（[VOICE_QUALITY_HIGH]）
+         */
+        @JvmOverloads
+        @JvmStatic
+        public fun create(
+            guildId: ID,
+            name: String,
+            type: Int = 1,
+            parentId: ID? = null,
+            limitAmount: Int = 99,
+            voiceQuality: Int = VOICE_QUALITY_NORMAL,
+        ): ChannelCreateRequest = ChannelCreateRequest(guildId, name, type, parentId, limitAmount, voiceQuality)
+        
+    }
+    
     init {
         require(type in 1..2) { "The 'type' must be 1(Text) or 2(Voice), but $type" }
         require(limitAmount in 1..99) { "The 'limitAmount' must between 1 and 99, but $limitAmount" }
         require(voiceQuality in 1..3) { "The 'voiceQuality' must between 1 and 3, but $voiceQuality" }
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out Channel>
         get() = ChannelView.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(guildId, name, type, parentId, limitAmount, voiceQuality)
-
+    
     @Serializable
     private data class Body(
         /** 是 服务器id */
         @SerialName("guild_id")
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val guildId: ID,
-
+        
         /** 是 频道名称 */
         val name: String,
-
+        
         /** 否 频道类型，1 文字，2 语音，默认为文字 */
         val type: Int = 1,
-
+        
         /** 否 父分组id */
         @SerialName("parent_id")
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val parentId: ID? = null,
-
+        
         /** 否 语音频道人数限制，最大99 */
         @SerialName("limit_amount")
         val limitAmount: Int = 99,
-
+        
         /** 否 语音音质，默认为2。1流畅，2正常，3高质量 */
         @SerialName("voice_quality")
         val voiceQuality: Int = 2,

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelDeleteRequest.kt
@@ -35,8 +35,19 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class ChannelDeleteRequest(private val channelId: ID) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("channel", "delete")
+public class ChannelDeleteRequest internal constructor(private val channelId: ID) : KookPostRequest<Unit>() {
+    public companion object Key : BaseKookApiRequestKey("channel", "delete") {
+    
+        /**
+         * 构建 [ChannelDeleteRequest].
+         * @param channelId 要删除的频道的ID
+         */
+        @JvmStatic
+        public fun create(channelId: ID): ChannelDeleteRequest {
+            return ChannelDeleteRequest(channelId)
+        }
+        
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelListRequest.kt
@@ -39,23 +39,31 @@ import love.forte.simbot.literal
  * request method: GET
  *
  */
-public class ChannelListRequest(
+public class ChannelListRequest internal constructor(
     private val guildId: ID,
-    /**
-     * 目标页数
-     */
     private val page: Int? = null,
-    /**
-     * 每页数据数量
-     */
     private val pageSize: Int? = null,
-    /**
-     * 频道类型, `1`为文字，`2`为语音, 默认为`1`.
-     */
     private val type: Int? = null,
 ) : KookGetRequest<KookApiResult.ListData<ChannelInfo>>() {
     public companion object Key : BaseKookApiRequestKey("channel", "list") {
         private val serializer = KookApiResult.ListData.serializer(ChannelInfoImpl.serializer())
+    
+        /**
+         * 构建 [ChannelListRequest]
+         * @param guildId 频道服务器ID
+         * @param page 目标页数
+         * @param pageSize 每页数据数量
+         * @param type 频道类型, `1`为文字，`2`为语音, 默认为`1`.
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            guildId: ID,
+            page: Int? = null,
+            pageSize: Int? = null,
+            type: Int? = null,
+        ): ChannelListRequest = ChannelListRequest(guildId, page, pageSize, type)
     }
     
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<ChannelInfo>>

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelViewRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/channel/ChannelViewRequest.kt
@@ -39,9 +39,17 @@ import love.forte.simbot.literal
  *
  * @author ForteScarlet
  */
-public class ChannelViewRequest(private val targetId: ID) : KookGetRequest<ChannelView>() {
+public class ChannelViewRequest internal constructor(private val targetId: ID) : KookGetRequest<ChannelView>() {
 
-    public companion object Key : BaseKookApiRequestKey("channel", "view")
+    public companion object Key : BaseKookApiRequestKey("channel", "view") {
+    
+        /**
+         * 构建 [ChannelViewRequest]
+         * @param targetId 目标频道ID
+         */
+        @JvmStatic
+        public fun create(targetId: ID): ChannelViewRequest = ChannelViewRequest(targetId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out ChannelView>
         get() = ChannelView.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildKickoutRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildKickoutRequest.kt
@@ -32,27 +32,33 @@ import love.forte.simbot.kook.api.KookPostRequest
  * request method: POST
  *
  */
-public class GuildKickoutRequest(
+public class GuildKickoutRequest internal constructor(
     guildId: ID,
     targetId: ID,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild", "kickout")
-
+    public companion object Key : BaseKookApiRequestKey("guild", "kickout") {
+        
+        /**
+         * 构造 [GuildKickoutRequest]
+         *
+         * @param guildId 频道服务器ID
+         * @param targetId 目标用户ID
+         */
+        @JvmStatic
+        public fun create(guildId: ID, targetId: ID): GuildKickoutRequest = GuildKickoutRequest(guildId, targetId)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override val body: Any = Body(guildId, targetId)
-
+    
     @Serializable
     private data class Body(
-        @SerialName("guild_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val guildId: ID,
-        @SerialName("target_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val targetId: ID,
+        @SerialName("guild_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val guildId: ID,
+        @SerialName("target_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val targetId: ID,
     )
-
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildLeaveRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildLeaveRequest.kt
@@ -32,8 +32,16 @@ import love.forte.simbot.kook.api.KookPostRequest
  * request method: POST
  *
  */
-public class GuildLeaveRequest(private val guildId: ID) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild", "leave")
+public class GuildLeaveRequest internal constructor(private val guildId: ID) : KookPostRequest<Unit>() {
+    public companion object Key : BaseKookApiRequestKey("guild", "leave") {
+    
+        /**
+         * 构造 [GuildLeaveRequest].
+         * @param guildId 目标频道服务器
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GuildLeaveRequest = GuildLeaveRequest(guildId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildListRequest.kt
@@ -39,32 +39,52 @@ import love.forte.simbot.kook.objects.Role
  *
  *
  */
-public class GuildListRequest @JvmOverloads constructor(
-    /**
-     * 目标页数
-     */
-    private val page: Int = -1,
-    /**
-     * 每页数据数量
-     */
-    private val pageSize: Int = -1,
-    /**
-     * 代表排序的字段, 比如-id代表id按DESC排序，id代表id按ASC排序。不一定有, 如果有，接口中会声明支持的排序字段。
-     */
-    private val sort: String? = null
-) :
-    KookGetRequest<KookApiResult.ListData<Guild>>() {
+public class GuildListRequest internal constructor(
+    private val page: Int, private val pageSize: Int, private val sort: String?
+) : KookGetRequest<KookApiResult.ListData<Guild>>() {
     public companion object Key : BaseKookApiRequestKey("guild", "list") {
         private val serializer = KookApiResult.ListData.serializer(GuildListElement.serializer())
-        public val DEFAULT: GuildListRequest = GuildListRequest()
+        
+        /**
+         * 全部使用默认值的 [GuildListRequest].
+         *
+         */
+        @JvmField
+        public val DEFAULT: GuildListRequest = GuildListRequest(-1, -1, null)
+        
+        /**
+         * 全部使用默认值的 [GuildListRequest].
+         * @see DEFAULT
+         */
+        @JvmStatic
+        public fun create(): GuildListRequest = DEFAULT
+        
+        /**
+         * 构造 [GuildListRequest].
+         * @param page 目标页数
+         * @param pageSize 每页数据数量
+         * @param sort 代表排序的字段, 比如-id代表id按DESC排序，id代表id按ASC排序。不一定有, 如果有，接口中会声明支持的排序字段。
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            page: Int = DEFAULT.page, pageSize: Int = DEFAULT.pageSize, sort: String? = DEFAULT.sort
+        ): GuildListRequest {
+            if (page == DEFAULT.page && pageSize == DEFAULT.pageSize && sort == DEFAULT.sort) {
+                return DEFAULT
+            }
+            
+            return GuildListRequest(page, pageSize, sort)
+        }
+        
     }
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<Guild>>
         get() = serializer
-
+    
     override fun ParametersBuilder.buildParameters() {
         if (page > 0) {
             append("page", page.toString())
@@ -74,7 +94,7 @@ public class GuildListRequest @JvmOverloads constructor(
         }
         appendIfNotnull("sort", sort)
     }
-
+    
 }
 
 
@@ -89,8 +109,7 @@ internal data class GuildListElement @ApiResultType constructor(
     /**
      * 服务器id
      */
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    override val id: ID,
+    @Serializable(ID.AsCharSequenceIDSerializer::class) override val id: ID,
     /**
      * 服务器名称
      */
@@ -102,14 +121,12 @@ internal data class GuildListElement @ApiResultType constructor(
     /**
      * 服务器主的id
      */
-    @SerialName("master_id")
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    override val masterId: ID,
+    @SerialName("master_id") @Serializable(ID.AsCharSequenceIDSerializer::class) override val masterId: ID,
     /**
      * 	服务器icon的地址
      */
     override val icon: String,
-
+    
     /**
      * 通知类型,
      * - `0` 代表默认使用服务器通知设置
@@ -117,9 +134,8 @@ internal data class GuildListElement @ApiResultType constructor(
      * - `2` 代表仅@被提及
      * - `3` 代表不接收通知
      */
-    @SerialName("notify_type")
-    override val notifyType: Int,
-
+    @SerialName("notify_type") override val notifyType: Int,
+    
     /**
      * 服务器默认使用语音区域
      */
@@ -127,30 +143,23 @@ internal data class GuildListElement @ApiResultType constructor(
     /**
      * 是否为公开服务器
      */
-    @SerialName("enable_open")
-    override val enableOpen: Boolean,
+    @SerialName("enable_open") override val enableOpen: Boolean,
     /**
      * 公开服务器id
      */
-    @SerialName("open_id")
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    override val openId: ID,
+    @SerialName("open_id") @Serializable(ID.AsCharSequenceIDSerializer::class) override val openId: ID,
     /**
      * 	默认频道id
      */
-    @SerialName("default_channel_id")
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    override val defaultChannelId: ID,
+    @SerialName("default_channel_id") @Serializable(ID.AsCharSequenceIDSerializer::class) override val defaultChannelId: ID,
     /**
      * 欢迎频道id
      */
-    @SerialName("welcome_channel_id")
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    override val welcomeChannelId: ID,
+    @SerialName("welcome_channel_id") @Serializable(ID.AsCharSequenceIDSerializer::class) override val welcomeChannelId: ID,
 ) : Guild {
     override val roles: List<Role>? = null
     override val channels: List<Channel>? = null
-
+    
     // 可选的
     override val maximumChannel: Int = -1
     override val createTime: Timestamp = Timestamp.NotSupport

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteCreateRequest.kt
@@ -32,41 +32,47 @@ import love.forte.simbot.kook.api.KookPostRequest
  * request method: POST
  *
  */
-public class GuildMuteCreateRequest(
-    /** 服务器id */
+public class GuildMuteCreateRequest internal constructor(
     private val guildId: ID,
-    /** 用户id */
     private val userId: ID,
-    /**
-     * 1代表麦克风闭麦，2代表耳机静音
-     *
-     * @see GuildMuteType.TYPE_MICROPHONE
-     * @see GuildMuteType.TYPE_EARPHONE
-     */
     private val type: Int
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild-mute", "create")
-
+    public companion object Key : BaseKookApiRequestKey("guild-mute", "create") {
+        
+        /**
+         * @param guildId 服务器id
+         * @param userId 用户id
+         * @param type 静音类型
+         * - 麦克风闭麦: 1 ([GuildMuteType.TYPE_MICROPHONE])
+         * - 耳机静音: 2 ([GuildMuteType.TYPE_EARPHONE])
+         *
+         * @see GuildMuteType
+         */
+        @JvmStatic
+        public fun create(guildId: ID, userId: ID, type: Int): GuildMuteCreateRequest =
+            GuildMuteCreateRequest(guildId, userId, type)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(guildId, userId, type)
-
+    
     @Serializable
     private data class Body(
-
+        
         /** 服务器id */
         @SerialName("guild_id")
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val guildId: ID,
-
+        
         /** 用户id */
         @SerialName("user_id")
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val userId: ID,
-
+        
         /** 1代表麦克风闭麦，2代表耳机静音 */
         val type: Int
     )

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteCreateRequest.kt
@@ -33,13 +33,12 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  */
 public class GuildMuteCreateRequest internal constructor(
-    private val guildId: ID,
-    private val userId: ID,
-    private val type: Int
+    private val guildId: ID, private val userId: ID, private val type: Int
 ) : KookPostRequest<Unit>() {
     public companion object Key : BaseKookApiRequestKey("guild-mute", "create") {
         
         /**
+         * 构造 [GuildMuteCreateRequest].
          * @param guildId 服务器id
          * @param userId 用户id
          * @param type 静音类型
@@ -64,14 +63,10 @@ public class GuildMuteCreateRequest internal constructor(
     private data class Body(
         
         /** 服务器id */
-        @SerialName("guild_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val guildId: ID,
+        @SerialName("guild_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val guildId: ID,
         
         /** 用户id */
-        @SerialName("user_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val userId: ID,
+        @SerialName("user_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val userId: ID,
         
         /** 1代表麦克风闭麦，2代表耳机静音 */
         val type: Int

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteDeleteRequest.kt
@@ -34,37 +34,38 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  */
 public class GuildMuteDeleteRequest(
-    /** 服务器id */
-    guildId: ID,
-    /** 用户id */
-    userId: ID,
-    /**
-     * 1代表麦克风闭麦，2代表耳机静音
-     *
-     * @see GuildMuteType.TYPE_MICROPHONE
-     * @see GuildMuteType.TYPE_EARPHONE
-     */
-    type: Int
+    guildId: ID, userId: ID, type: Int
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild-mute", "delete")
-
+    public companion object Key : BaseKookApiRequestKey("guild-mute", "delete") {
+        
+        /**
+         * 构造 [GuildMuteDeleteRequest].
+         * @param guildId 服务器id
+         * @param userId 用户id
+         * @param type 静音类型
+         * - 麦克风闭麦: 1 ([GuildMuteType.TYPE_MICROPHONE])
+         * - 耳机静音: 2 ([GuildMuteType.TYPE_EARPHONE])
+         *
+         * @see GuildMuteType
+         */
+        @JvmStatic
+        public fun create(guildId: ID, userId: ID, type: Int): GuildMuteDeleteRequest =
+            GuildMuteDeleteRequest(guildId, userId, type)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()
-
+    
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override val body: Any = Body(guildId, userId, type)
-
+    
     @Serializable
     private data class Body(
         /** 服务器id */
-        @SerialName("guild_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val guildId: ID,
+        @SerialName("guild_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val guildId: ID,
         /** 用户id */
-        @SerialName("user_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val userId: ID,
+        @SerialName("user_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val userId: ID,
         /** 1代表麦克风闭麦，2代表耳机静音 */
         val type: Int
     )

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteDeleteRequest.kt
@@ -33,7 +33,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  * request method: POST
  *
  */
-public class GuildMuteDeleteRequest(
+public class GuildMuteDeleteRequest internal constructor(
     guildId: ID, userId: ID, type: Int
 ) : KookPostRequest<Unit>() {
     public companion object Key : BaseKookApiRequestKey("guild-mute", "delete") {

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildMuteListRequest.kt
@@ -36,10 +36,17 @@ import love.forte.simbot.literal
  * request method: GET
  *
  */
-public sealed class GuildMuteListRequest(
-    private val guildId: ID
-) : KookGetRequest<GuildMuteList>() {
-    public companion object Key : BaseKookApiRequestKey("guild-mute", "list")
+public class GuildMuteListRequest(private val guildId: ID) : KookGetRequest<GuildMuteList>() {
+    public companion object Key : BaseKookApiRequestKey("guild-mute", "list") {
+    
+        /**
+         * 构造 [GuildMuteListRequest].
+         * @param guildId 频道服务器id
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GuildMuteListRequest =
+            GuildMuteListRequest(guildId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out GuildMuteList>
         get() = GuildMuteList.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildNicknameRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildNicknameRequest.kt
@@ -34,12 +34,36 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class GuildNicknameRequest(
+public class GuildNicknameRequest internal constructor(
     guildId: ID,
-    nickname: String? = null,
     userId: ID? = null,
+    nickname: String? = null,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild", "nickname")
+    public companion object Key : BaseKookApiRequestKey("guild", "nickname") {
+    
+        /**
+         * 构造 [GuildNicknameRequest].
+         * @param guildId 频道服务器ID
+         * @param userId 要修改昵称的目标用户 ID，不传则修改当前登陆用户的昵称
+         * @param nickname 昵称，2 - 64 长度，不传则清空昵称
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, userId: ID? = null, nickname: String? = null): GuildNicknameRequest =
+            GuildNicknameRequest(guildId, userId, nickname)
+        
+        /**
+         * 构造 [GuildNicknameRequest], 修改当前登录用户的昵称
+         * @param guildId 频道服务器ID
+         * @param nickname 昵称，2 - 64 长度，不传则清空昵称
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, nickname: String? = null): GuildNicknameRequest =
+            GuildNicknameRequest(guildId, null, nickname)
+    }
 
     init {
         if (nickname != null) {

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildUserListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildUserListRequest.kt
@@ -35,7 +35,7 @@ import love.forte.simbot.literal
  * request method: GET
  *
  */
-public class GuildUserListRequest(
+public class GuildUserListRequest internal constructor(
     /**	是 服务器的 ID */
     private val guildId: ID,
     /**	否 服务器中频道的 ID */
@@ -55,7 +55,11 @@ public class GuildUserListRequest(
     /**	否 每页数据数量 */
     private val pageSize: Int = -1,
 ) : KookGetRequest<GuildUserList>() {
-
+    
+    @Deprecated(
+        "Use GuildUserListRequest.create(...)",
+        ReplaceWith("GuildUserListRequest.create(guildId = guildId, channelId = channelId, page = page, pageSize = pageSize)")
+    )
     @JvmOverloads
     public constructor(
         guildId: ID, channelId: ID? = null,
@@ -67,15 +71,55 @@ public class GuildUserListRequest(
         page = page,
         pageSize = pageSize
     )
-
-    public companion object Key : BaseKookApiRequestKey("guild", "user-list")
-
+    
+    public companion object Key : BaseKookApiRequestKey("guild", "user-list") {
+        
+        /**
+         * 构造 [GuildUserListRequest]
+         * @param guildId 服务器的 ID
+         * @param channelId 服务器中频道的 ID
+         * @param search 搜索关键字，在用户名或昵称中搜索
+         * @param roleId 角色 ID，获取特定角色的用户列表
+         * @param mobileVerified 只能为0或1，0是未认证，1是已认证
+         * @param activeTimeSort 根据活跃时间排序，0是顺序排列，1是倒序排列
+         * @param joinedAtSort 根据加入时间排序，0是顺序排列，1是倒序排列
+         * @param page 目标页
+         * @param pageSize 每页数据数量
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            guildId: ID,
+            channelId: ID? = null,
+            search: String? = null,
+            roleId: ID? = null,
+            mobileVerified: Boolean? = null,
+            activeTimeSort: Int? = null,
+            joinedAtSort: Int? = null,
+            page: Int = -1,
+            pageSize: Int = -1,
+        ): GuildUserListRequest =
+            GuildUserListRequest(
+                guildId,
+                channelId,
+                search,
+                roleId,
+                mobileVerified,
+                activeTimeSort,
+                joinedAtSort,
+                page,
+                pageSize
+            )
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out GuildUserList>
         get() = GuildUserList.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun ParametersBuilder.buildParameters() {
         append("guild_id", guildId.literal)
         appendIfNotnull("channelId", channelId) { it.literal }
@@ -91,8 +135,8 @@ public class GuildUserListRequest(
             append("page_size", pageSize.toString())
         }
     }
-
-
+    
+    
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildViewRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/GuildViewRequest.kt
@@ -40,8 +40,16 @@ import love.forte.simbot.literal
  * request method: GET
  *
  */
-public class GuildViewRequest(private val guildId: ID) : KookGetRequest<Guild>() {
-    public companion object Key : BaseKookApiRequestKey("guild", "view")
+public class GuildViewRequest internal constructor(private val guildId: ID) : KookGetRequest<Guild>() {
+    public companion object Key : BaseKookApiRequestKey("guild", "view") {
+        /**
+         * 构造 [GuildViewRequest].
+         *
+         * @param guildId 频道服务器ID
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GuildViewRequest = GuildViewRequest(guildId)
+    }
 
     override val apiPaths: List<String>
         get() = apiPathList

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/emoji/GuildEmojiListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/emoji/GuildEmojiListRequest.kt
@@ -18,15 +18,22 @@ import love.forte.simbot.literal
  *
  * @author ForteScarlet
  */
-public class GuildEmojiListRequest(
+public class GuildEmojiListRequest internal constructor(
     private val guildId: ID,
-    private val pageRequest: PageRequestParameters? = null,
+    private val pageRequest: PageRequestParameters?,
 ) : KookGetRequest<KookApiResult.ListData<GuildEmojiData>>() {
-    public constructor(guildId: ID): this(guildId, null)
-    
     public companion object Key : BaseKookApiRequestKey("guild-emoji", "list") {
         private val serializer = KookApiResult.ListData.serializer(GuildEmojiDataImpl.serializer())
-        
+    
+        /**
+         * 构建 [GuildEmojiListRequest].
+         * @param guildId 频道服务器ID
+         * @param pageRequest 分页信息
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, pageRequest: PageRequestParameters? = null): GuildEmojiListRequest
+            = GuildEmojiListRequest(guildId, pageRequest)
     }
     
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<GuildEmojiData>>

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleCreateRequest.kt
@@ -37,20 +37,32 @@ import love.forte.simbot.kook.objects.Permissions
  *
  * @author ForteScarlet
  */
-public class GuildRoleCreateRequest(
+public class GuildRoleCreateRequest internal constructor(
     private val guildId: ID,
     private val name: String? = null,
 ) : KookPostRequest<GuildRoleCreated>() {
-    public companion object Key : BaseKookApiRequestKey("guild-role", "create")
-
+    public companion object Key : BaseKookApiRequestKey("guild-role", "create") {
+        
+        /**
+         * 构建 [GuildRoleCreateRequest]
+         * @param guildId 目标频道
+         * @param name 角色名
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, name: String? = null): GuildRoleCreateRequest =
+            GuildRoleCreateRequest(guildId, name)
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out GuildRoleCreated>
         get() = GuildRoleCreated.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(guildId, name)
-
+    
     @Serializable
     private data class Body(
         @SerialName("guild_id")
@@ -93,25 +105,25 @@ public data class GuildRoleCreated @ApiResultType constructor(
      * 只能为0或者1，该角色是否可以被提及
      */
     public val mentionable: Int,
-
+    
     /**
      * 权限信息。Java中可以通过 [permissionsValue] 得到int类型的字面值。
      */
     @SerialName("permissions")
     public val permissions: Permissions,
 ) : Role, Comparable<GuildRoleCreated> {
-
+    
     override fun compareTo(other: GuildRoleCreated): Int {
         return position.compareTo(other.position)
     }
-
+    
     /**
      * 此处的管理员权限判断为完全的 [管理员][PermissionType], 如果你想要更细致的判断，请通过 [PermissionType] 自行处理。
      */
     override val isAdmin: Boolean
         get() = PermissionType.ADMIN in permissions
-
-
+    
+    
     public val permissionsValue: Int get() = permissions.perm.toInt()
-
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleDeleteRequest.kt
@@ -40,26 +40,25 @@ public class GuildRoleDeleteRequest internal constructor(
     private val roleId: ID,
 ) : KookPostRequest<Unit>() {
     public companion object Key : BaseKookApiRequestKey("guild-role", "delete") {
-    
+        
         /**
          * 构建 [GuildRoleDeleteRequest]
          * @param guildId 频道ID
          * @param roleId 角色ID
          */
         @JvmStatic
-        public fun create(guildId: ID, roleId: ID): GuildRoleDeleteRequest
-            = GuildRoleDeleteRequest(guildId, roleId)
+        public fun create(guildId: ID, roleId: ID): GuildRoleDeleteRequest = GuildRoleDeleteRequest(guildId, roleId)
         
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(guildId, roleId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("guild_id")
@@ -69,5 +68,5 @@ public class GuildRoleDeleteRequest internal constructor(
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val roleId: ID,
     )
-
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleDeleteRequest.kt
@@ -35,13 +35,22 @@ import love.forte.simbot.kook.api.KookPostRequest
  * `/api/v3/guild-role/delete`
  *
  */
-public class GuildRoleDeleteRequest(
-    /** 服务器id */
+public class GuildRoleDeleteRequest internal constructor(
     private val guildId: ID,
-    /** 角色id */
     private val roleId: ID,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("guild-role", "delete")
+    public companion object Key : BaseKookApiRequestKey("guild-role", "delete") {
+    
+        /**
+         * 构建 [GuildRoleDeleteRequest]
+         * @param guildId 频道ID
+         * @param roleId 角色ID
+         */
+        @JvmStatic
+        public fun create(guildId: ID, roleId: ID): GuildRoleDeleteRequest
+            = GuildRoleDeleteRequest(guildId, roleId)
+        
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleGrantRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleGrantRequest.kt
@@ -33,7 +33,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * `/api/v3/guild-role/grant`
  */
-public class GuildRoleGrantRequest(
+public class GuildRoleGrantRequest internal constructor(
     /** 服务器id */
     private val guildId: ID,
     /** 用户id */
@@ -41,16 +41,28 @@ public class GuildRoleGrantRequest(
     /** 角色id */
     private val roleId: ID,
 ) : KookPostRequest<UserRoleOperated>() {
-    public companion object Key : BaseKookApiRequestKey("guild-role", "grant")
-
+    public companion object Key : BaseKookApiRequestKey("guild-role", "grant") {
+        
+        /**
+         * 构建 [GuildRoleGrantRequest]
+         * @param guildId 频道ID
+         * @param userId 用户ID
+         * @param roleId 角色ID
+         */
+        @JvmStatic
+        public fun create(guildId: ID, userId: ID, roleId: ID): GuildRoleGrantRequest =
+            GuildRoleGrantRequest(guildId, userId, roleId)
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out UserRoleOperated>
         get() = UserRoleOperated.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     protected override fun createBody(): Any = Body(guildId, userId, roleId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("guild_id")

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleGrantRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleGrantRequest.kt
@@ -34,11 +34,8 @@ import love.forte.simbot.kook.api.KookPostRequest
  * `/api/v3/guild-role/grant`
  */
 public class GuildRoleGrantRequest internal constructor(
-    /** 服务器id */
     private val guildId: ID,
-    /** 用户id */
     private val userId: ID,
-    /** 角色id */
     private val roleId: ID,
 ) : KookPostRequest<UserRoleOperated>() {
     public companion object Key : BaseKookApiRequestKey("guild-role", "grant") {

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleListRequest.kt
@@ -36,27 +36,36 @@ import love.forte.simbot.literal
  *
  * @param guildId 服务器的id
  */
-public class GuildRoleListRequest(
+public class GuildRoleListRequest internal constructor(
     public val guildId: ID,
     private val pageRequest: PageRequestParameters? = null,
 ) : KookGetRequest<KookApiResult.ListData<Role>>() {
-    public constructor(guildId: ID): this(guildId, null)
-    
     public companion object Key : BaseKookApiRequestKey("guild-role", "list") {
         private val serializer = KookApiResult.ListData.serializer(RoleImpl.serializer())
+        
+        /**
+         * 构建 [GuildRoleListRequest]
+         * @param guildId 频道服务器ID
+         * @param pageRequest 分页查询参数
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, pageRequest: PageRequestParameters? = null): GuildRoleListRequest =
+            GuildRoleListRequest(guildId, pageRequest)
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<Role>>
         get() = serializer
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun ParametersBuilder.buildParameters() {
         append("guild_id", guildId.literal)
         pageRequest?.appendTo(this)
     }
-
+    
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleRevokeRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleRevokeRequest.kt
@@ -34,24 +34,33 @@ import love.forte.simbot.kook.api.KookPostRequest
  * `/api/v3/guild-role/revoke`
  *
  */
-public class GuildRoleRevokeRequest(
-    /** 服务器ID */
+public class GuildRoleRevokeRequest internal constructor(
     private val guildId: ID,
-    /** 角色ID */
     private val roleId: ID,
-    /** 用户ID */
     private val userId: ID,
 ) : KookPostRequest<UserRoleOperated>() {
-    public companion object Key : BaseKookApiRequestKey("guild-role", "revoke")
-
+    public companion object Key : BaseKookApiRequestKey("guild-role", "revoke") {
+        
+        /**
+         * 构造 [GuildRoleRevokeRequest]
+         * @param guildId 服务器ID
+         * @param roleId 角色ID
+         * @param userId 用户ID
+         */
+        @JvmStatic
+        public fun create(guildId: ID, roleId: ID, userId: ID): GuildRoleRevokeRequest =
+            GuildRoleRevokeRequest(guildId, roleId, userId)
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out UserRoleOperated>
         get() = UserRoleOperated.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(guildId, roleId, userId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("guild_id")

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleUpdateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/guild/role/GuildRoleUpdateRequest.kt
@@ -39,63 +39,116 @@ import love.forte.simbot.kook.util.BooleanToIntSerializer
  * `/api/v3/guild-role/update`
  *
  */
-public class GuildRoleUpdateRequest(override val body: Body) : KookPostRequest<Role>() {
+public class GuildRoleUpdateRequest internal constructor(override val body: Body) : KookPostRequest<Role>() {
+    @Deprecated(
+        "Use GuildRoleUpdateRequest.create(...)",
+        ReplaceWith("GuildRoleUpdateRequest.create(roleId, name, color, position, isHoist, isMentionable, permissions)")
+    )
     public constructor(
-        /** 角色的id */
         roleId: ID,
-        /** 角色的名称 */
         name: String,
-        /** 角色的色值0x000000 - 0xFFFFFF */
         color: Int,
-        /** 顺序，值越小载靠前 */
         position: Int,
-        /** 只能为0或者1，是否把该角色的用户在用户列表排到前面 */
         isHoist: Boolean,
-        /** 只能为0或者1，该角色是否可以被提及 */
         isMentionable: Boolean,
-        /** 权限,参见 [权限说明](https://developer.kaiheila.cn/doc/http/guild-role#权限说明) */
         permissions: Int,
     ) : this(Body(roleId, name, color, position, isHoist, isMentionable, permissions))
-
-    public companion object Key : BaseKookApiRequestKey("guild-role", "update")
-
+    
+    public companion object Key : BaseKookApiRequestKey("guild-role", "update") {
+        
+        /**
+         * 使用最基础的 [Body] 参数构造 [GuildRoleUpdateRequest].
+         *
+         * @param body 构造参数
+         */
+        @JvmStatic
+        public fun create(body: Body): GuildRoleUpdateRequest = GuildRoleUpdateRequest(body)
+        
+        /**
+         *
+         * 使用与 [Body] 基本一致的参数构造 [GuildRoleUpdateRequest].
+         *
+         * @param roleId 角色的id
+         * @param name 角色的名称
+         * @param color 角色的色值0x000000 - 0xFFFFFF
+         * @param position 顺序，值越小载靠前
+         * @param isHoist 是否把该角色的用户在用户列表排到前面
+         * @param isMentionable 该角色是否可以被提及
+         * @param permissions 权限,参见 [权限说明](https://developer.kaiheila.cn/doc/http/guild-role#权限说明)
+         *
+         *
+         */
+        @JvmStatic
+        public fun create(
+            roleId: ID,
+            name: String,
+            color: Int,
+            position: Int,
+            isHoist: Boolean,
+            isMentionable: Boolean,
+            permissions: Int,
+        ): GuildRoleUpdateRequest =
+            GuildRoleUpdateRequest(Body(roleId, name, color, position, isHoist, isMentionable, permissions))
+        
+        /**
+         *
+         * 使用与 [Body] 基本一致的参数构造 [GuildRoleUpdateRequest].
+         *
+         * @param roleId 角色的id
+         * @param name 角色的名称
+         * @param color 角色的色值0x000000 - 0xFFFFFF
+         * @param position 顺序，值越小载靠前
+         * @param isHoist 是否把该角色的用户在用户列表排到前面
+         * @param isMentionable 该角色是否可以被提及
+         * @param permissions 权限,参见 [权限说明](https://developer.kaiheila.cn/doc/http/guild-role#权限说明)
+         *
+         */
+        @JvmStatic
+        public fun create(
+            roleId: ID,
+            name: String,
+            color: Int,
+            position: Int,
+            isHoist: Boolean,
+            isMentionable: Boolean,
+            permissions: Permissions,
+        ): GuildRoleUpdateRequest =
+            create(roleId, name, color, position, isHoist, isMentionable, permissions.perm.toInt())
+        
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Role>
         get() = RoleImpl.serializer()
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Body = body
-
-
+    
+    
     /**
      * 用于 [GuildRoleUpdateRequest] 的请求体类型。
      */
     @Serializable
     public data class Body(
         /** 角色的id */
-        @SerialName("role_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val roleId: ID,
-
+        @SerialName("role_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val roleId: ID,
+        
         /** 角色的名称 */
         val name: String,
-
+        
         /** 角色的色值0x000000 - 0xFFFFFF */
         val color: Int,
-
+        
         /** 顺序，值越小载靠前 */
         val position: Int,
-
+        
         /** 只能为0或者1，是否把该角色的用户在用户列表排到前面 */
-        @SerialName("hoist")
-        @Serializable(BooleanToIntSerializer::class)
-        val isHoist: Boolean,
-
+        @SerialName("hoist") @Serializable(BooleanToIntSerializer::class) val isHoist: Boolean,
+        
         /** 只能为0或者1，该角色是否可以被提及 */
-        @SerialName("mentionable")
-        @Serializable(BooleanToIntSerializer::class)
-        val isMentionable: Boolean,
+        @SerialName("mentionable") @Serializable(BooleanToIntSerializer::class) val isMentionable: Boolean,
         /**
          * 权限,参见 [权限说明](https://developer.kaiheila.cn/doc/http/guild-role#权限说明)
          *
@@ -104,7 +157,7 @@ public class GuildRoleUpdateRequest(override val body: Body) : KookPostRequest<R
          */
         val permissions: Int,
     )
-
+    
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/intimacy/IntimacyIndexRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/intimacy/IntimacyIndexRequest.kt
@@ -35,13 +35,19 @@ import love.forte.simbot.kook.api.KookGetRequest
  * method GET
  *
  */
-public class IntimacyIndexRequest(
-    /**
-     * 用户ID
-     */
+public class IntimacyIndexRequest internal constructor(
     private val userId: ID,
 ) : KookGetRequest<IntimacyIndex>() {
-    public companion object Key : BaseKookApiRequestKey("intimacy", "index")
+    public companion object Key : BaseKookApiRequestKey("intimacy", "index") {
+    
+        /**
+         * 构造 [IntimacyIndexRequest].
+         * @param userId 用户ID
+         *
+         */
+        @JvmStatic
+        public fun create(userId: ID): IntimacyIndexRequest = IntimacyIndexRequest(userId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out IntimacyIndex>
         get() = IntimacyIndex.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/intimacy/IntimacyUpdateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/intimacy/IntimacyUpdateRequest.kt
@@ -32,7 +32,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * method POST
  */
-public class IntimacyUpdateRequest @JvmOverloads constructor(
+public class IntimacyUpdateRequest internal constructor(
     /**
      * 用户 id
      */
@@ -50,20 +50,39 @@ public class IntimacyUpdateRequest @JvmOverloads constructor(
      */
     private val imgId: ID? = null
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("intimacy", "update")
-
+    public companion object Key : BaseKookApiRequestKey("intimacy", "update") {
+    
+        /**
+         * 构造 [IntimacyUpdateRequest].
+         *
+         * @param userId 用户 id
+         * @param score 亲密度，0-2200
+         * @param socialInfo 机器人与用户的社交信息，500 字以内
+         * @param imgId 表情ID
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            userId: ID,
+            score: Int? = null,
+            socialInfo: String? = null,
+            imgId: ID? = null
+        ): IntimacyUpdateRequest = IntimacyUpdateRequest(userId, score, socialInfo, imgId)
+    }
+    
     init {
         Simbot.require(score == null || score in 0..2200) { "Score must in 0 .. 2200" }
         Simbot.require(socialInfo?.length?.let { it <= 500 } ?: true) { "Social info must <= 500." }
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out Unit>
         get() = Unit.serializer()
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun createBody(): Any = Body(userId, score, socialInfo, imgId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("user_id")

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteCreateRequest.kt
@@ -55,7 +55,7 @@ import love.forte.simbot.kook.api.invite.InviteCreateRequest.Key.SETTING_TIMES_U
  *
  * method POST
  */
-public class InviteCreateRequest @JvmOverloads constructor(
+public class InviteCreateRequest internal constructor(
     /**
      * 服务器 id. 服务器 id 或者频道 id 必须填一个
      */
@@ -74,181 +74,218 @@ public class InviteCreateRequest @JvmOverloads constructor(
      * - 43200 => 12 个小时; see [DURATION_NEVER].
      * - 86400 => 1 天; see [DURATION_NEVER].
      * - 604800 => 7 天; see [DURATION_NEVER].
-     *
-     * 你可以参考 [InviteCreateRequest] 中以 `DURATION_` 开头的常量，例如 [DURATION_NEVER].
-     *
-     * @see DURATION_NEVER
-     * @see DURATION_HALF_HOUR
-     * @see DURATION_ONE_HOUR
-     * @see DURATION_SIX_HOURS
-     * @see DURATION_TWELVE_HOURS
-     * @see DURATION_HALF_DAY
-     * @see DURATION_ONE_DAY
-     * @see DURATION_SEVEN_DAYS
-     * @see DURATION_ONE_WEEK
-     *
      */
     private val duration: Int = DURATION_ONE_WEEK,
-
+    
     /**
      * 设置的次数，默认-1。可选值：
-     * -1 => 无限制；
-     * 1 => 1 次使用；
-     * 5 => 5 次使用；
-     * 10 => 10 次使用；
-     * 25 => 25 次使用；
-     * 50 => 50 次使用；
-     * 100 => 100 次使用；
-     *
-     * 你可以参考 [InviteCreateRequest] 中以 `SETTING_TIMES_` 开头的常量，例如 [SETTING_TIMES_UNLIMITED].
-     *
-     * @see SETTING_TIMES_UNLIMITED
-     * @see SETTING_TIMES_ONE
-     * @see SETTING_TIMES_1
-     * @see SETTING_TIMES_FIVE
-     * @see SETTING_TIMES_5
-     * @see SETTING_TIMES_TEN
-     * @see SETTING_TIMES_10
-     * @see SETTING_TIMES_TWENTY_FIVE
-     * @see SETTING_TIMES_25
-     * @see SETTING_TIMES_FIFTY
-     * @see SETTING_TIMES_50
-     * @see SETTING_TIMES_ONE_HUNDRED
-     * @see SETTING_TIMES_100
+     * - -1 => 无限制；
+     * - 1 => 1 次使用；
+     * - 5 => 5 次使用；
+     * - 10 => 10 次使用；
+     * - 25 => 25 次使用；
+     * - 50 => 50 次使用；
+     * - 100 => 100 次使用；
      */
     private val settingTimes: Int = SETTING_TIMES_UNLIMITED
 
 ) : KookPostRequest<InviteCreated>() {
-
-
+    
+    
     @Suppress("MemberVisibilityCanBePrivate")
     public companion object Key : BaseKookApiRequestKey("invite", "create") {
-
+        
         //region duration常量
         /** 0 => 永不 */
         public const val DURATION_NEVER: Int = 0
-
+        
         /** 1800 => 0.5 小时 => 半个小时 */
         public const val DURATION_HALF_HOUR: Int = 1800
-
+        
         /** 3600 => 1 个小时 */
         public const val DURATION_ONE_HOUR: Int = 3600
-
+        
         /** 21600 => 6 个小时 */
         public const val DURATION_SIX_HOURS: Int = 21600
-
+        
         /** 43200 => 12 个小时 => 半天 */
         public const val DURATION_TWELVE_HOURS: Int = 43200
-
+        
         /**
          * 43200 => 12 个小时 => 半天
          * @see DURATION_TWELVE_HOURS
          * */
         public const val DURATION_HALF_DAY: Int = DURATION_TWELVE_HOURS
-
+        
         /** 86400 => 1 天; */
         public const val DURATION_ONE_DAY: Int = 86400
-
+        
         /** 604800 => 7 天 */
         public const val DURATION_SEVEN_DAYS: Int = 604800
-
+        
         /**
          * 604800 => 7 天;
          * @see DURATION_SEVEN_DAYS
          */
         public const val DURATION_ONE_WEEK: Int = DURATION_SEVEN_DAYS
         //endregion
-
+        
         //region settingTimes常量
         /** -1 => 无限制 */
         public const val SETTING_TIMES_UNLIMITED: Int = -1
-
+        
         /** 1 => 1 次使用 */
         public const val SETTING_TIMES_ONE: Int = 1
-
+        
         /** 1 => 1 次使用 */
         public const val SETTING_TIMES_1: Int = SETTING_TIMES_ONE
-
+        
         /** 5 => 5 次使用 */
         public const val SETTING_TIMES_FIVE: Int = 5
-
+        
         /** 5 => 5 次使用 */
         public const val SETTING_TIMES_5: Int = SETTING_TIMES_FIVE
-
+        
         /** -10 => 10 次使用 */
         public const val SETTING_TIMES_TEN: Int = 10
-
+        
         /** -10 => 10 次使用 */
         public const val SETTING_TIMES_10: Int = SETTING_TIMES_TEN
-
+        
         /** 25 => 25 次使用 */
         public const val SETTING_TIMES_TWENTY_FIVE: Int = 25
-
+        
         /** 25 => 25 次使用 */
         public const val SETTING_TIMES_25: Int = SETTING_TIMES_TWENTY_FIVE
-
+        
         /** 50 => 50 次使用 */
         public const val SETTING_TIMES_FIFTY: Int = 50
-
+        
         /** 50 => 50 次使用 */
         public const val SETTING_TIMES_50: Int = SETTING_TIMES_FIFTY
-
+        
         /** 100 => 100 次使用 */
         public const val SETTING_TIMES_ONE_HUNDRED: Int = 100
-
+        
         /** 100 => 100 次使用 */
         public const val SETTING_TIMES_100: Int = SETTING_TIMES_ONE_HUNDRED
         //endregion
-
-
+        
         /**
-         * 通过 channelId 构建请求。
-         * @see InviteCreateRequest
+         * 根据完整参数构造 [InviteCreateRequest]. 也可参考 [byGuild] 或 [byChannel] 来避免手误。
+         *
+         * @see byGuild
+         * @see byChannel
+         *
+         * @param guildId 服务器 id. [服务器 id][guildId] 或者 [频道 id][channelId] 必须填一个
+         * @param channelId 频道 id. [服务器 id][guildId] 或者 [频道 id][channelId] 必须填一个
+         * @param duration 邀请链接有效时长（秒），默认 [7天][DURATION_ONE_WEEK]。
+         * 可选值：
+         * - 0 => 永不; see [DURATION_NEVER].
+         * - 1800 => 0.5 小时; see [DURATION_HALF_HOUR].
+         * - 3600 => 1 个小时; see [DURATION_ONE_HOUR].
+         * - 21600 => 6 个小时; see [DURATION_SIX_HOURS].
+         * - 43200 => 12 个小时; see [DURATION_TWELVE_HOURS].
+         * - 86400 => 1 天; see [DURATION_ONE_DAY].
+         * - 604800 => 7 天; see [DURATION_SEVEN_DAYS].
+         *
+         * 你可以参考 [InviteCreateRequest] 中以 `DURATION_` 开头的常量，例如 [DURATION_NEVER].
+         *
+         *
+         * @see DURATION_NEVER
+         * @see DURATION_HALF_HOUR
+         * @see DURATION_ONE_HOUR
+         * @see DURATION_SIX_HOURS
+         * @see DURATION_TWELVE_HOURS
+         * @see DURATION_HALF_DAY
+         * @see DURATION_ONE_DAY
+         * @see DURATION_SEVEN_DAYS
+         * @see DURATION_ONE_WEEK
+         *
+         * @param settingTimes 设置的次数，默认[-1][SETTING_TIMES_UNLIMITED]。可选值：
+         * - -1 => 无限制；
+         * - 1 => 1 次使用；
+         * - 5 => 5 次使用；
+         * - 10 => 10 次使用；
+         * - 25 => 25 次使用；
+         * - 50 => 50 次使用；
+         * - 100 => 100 次使用；
+         *
+         * 你可以参考 [InviteCreateRequest] 中以 `SETTING_TIMES_` 开头的常量，例如 [SETTING_TIMES_UNLIMITED].
+         *
+         * @see SETTING_TIMES_UNLIMITED
+         * @see SETTING_TIMES_ONE
+         * @see SETTING_TIMES_1
+         * @see SETTING_TIMES_FIVE
+         * @see SETTING_TIMES_5
+         * @see SETTING_TIMES_TEN
+         * @see SETTING_TIMES_10
+         * @see SETTING_TIMES_TWENTY_FIVE
+         * @see SETTING_TIMES_25
+         * @see SETTING_TIMES_FIFTY
+         * @see SETTING_TIMES_50
+         * @see SETTING_TIMES_ONE_HUNDRED
+         * @see SETTING_TIMES_100
          */
         @JvmStatic
         @JvmOverloads
-        public fun byChannel(channelId: ID, duration: Int = DURATION_ONE_WEEK, settingTimes: Int = SETTING_TIMES_UNLIMITED): InviteCreateRequest {
-            return InviteCreateRequest(
-                guildId = null,
-                channelId = channelId,
-                duration, settingTimes
-            )
-        }
-
+        public fun create(
+            guildId: ID? = null,
+            channelId: ID? = null,
+            duration: Int = DURATION_ONE_WEEK,
+            settingTimes: Int = SETTING_TIMES_UNLIMITED
+        ): InviteCreateRequest =
+            InviteCreateRequest(guildId, channelId, duration, settingTimes)
+        
+        
         /**
-         * 通过 guildId 构建请求。
-         * @see InviteCreateRequest
+         * 通过 channelId 构建请求。参数含义描述参考 [create]
+         * @see create
          */
         @JvmStatic
         @JvmOverloads
-        public fun byGuild(guildId: ID, duration: Int = DURATION_ONE_WEEK, settingTimes: Int = SETTING_TIMES_UNLIMITED): InviteCreateRequest {
-            return InviteCreateRequest(
-                guildId = guildId,
-                channelId = null,
-                duration, settingTimes
-            )
+        public fun byChannel(
+            channelId: ID,
+            duration: Int = DURATION_ONE_WEEK,
+            settingTimes: Int = SETTING_TIMES_UNLIMITED
+        ): InviteCreateRequest {
+            return create(null, channelId, duration, settingTimes)
         }
-
+        
+        /**
+         * 通过 guildId 构建请求。参数含义描述参考 [create]
+         * @see create
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun byGuild(
+            guildId: ID,
+            duration: Int = DURATION_ONE_WEEK,
+            settingTimes: Int = SETTING_TIMES_UNLIMITED
+        ): InviteCreateRequest {
+            return create(guildId, null, duration, settingTimes)
+        }
+        
     }
-
+    
     init {
         Simbot.require(guildId != null || channelId != null) {
             "A guild id or channel id must exist"
         }
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out InviteCreated>
         get() = InviteCreated.serializer()
-
+    
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun createBody(): Any = Body(
         guildId,
         channelId,
         duration,
         settingTimes
     )
-
+    
     @Serializable
     private data class Body(
         @SerialName("guild_id") @Serializable(ID.AsCharSequenceIDSerializer::class)
@@ -258,10 +295,10 @@ public class InviteCreateRequest @JvmOverloads constructor(
         val duration: Int,
         @SerialName("setting_times")
         val settingTimes: Int
-
+    
     )
-
-
+    
+    
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteDeleteRequest.kt
@@ -33,29 +33,33 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * method POST
  */
-public class InviteDeleteRequest(
-    /**
-     * 邀请码
-     */
+public class InviteDeleteRequest internal constructor(
     private val urlCode: String,
-
-    /**
-     * 服务器 id
-     */
     private val guildId: ID? = null,
-
-    /**
-     * 	服务器频道 ID
-     */
     private val channelId: ID? = null,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("invite", "delete")
-
+    public companion object Key : BaseKookApiRequestKey("invite", "delete") {
+        
+        /**
+         * 构造 [InviteDeleteRequest].
+         *
+         * @param urlCode 邀请码
+         * @param guildId 服务器 id
+         * @param channelId 服务器频道 id
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(urlCode: String, guildId: ID? = null, channelId: ID? = null): InviteDeleteRequest =
+            InviteDeleteRequest(urlCode, guildId, channelId)
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun createBody(): Any = Body(urlCode, guildId, channelId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("url_code") val urlCode: String,
@@ -66,5 +70,5 @@ public class InviteDeleteRequest(
         @Serializable(ID.AsCharSequenceIDSerializer::class)
         val channelId: ID?,
     )
-
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/invite/InviteListRequest.kt
@@ -34,12 +34,8 @@ import love.forte.simbot.literal
  *
  * method: GET
  *
- * @param guildId 服务器 id. 服务器 id 或者频道 id 必须填一个
- * @param channelId 频道 id. 服务器 id 或者频道 id 必须填一个
- * @param page 目标页数. 不小于0时有效。
- * @param pageSize 每页数据数量. 不小于0时有效。
  */
-public class InviteListRequest(
+public class InviteListRequest internal constructor(
     private val guildId: ID?,
     private val channelId: ID?,
     private val page: Int = -1,
@@ -47,20 +43,32 @@ public class InviteListRequest(
 ) : KookGetRequest<KookApiResult.ListData<InviteInfo>>() {
     public companion object Key : BaseKookApiRequestKey("invite", "list") {
         private val serializer = KookApiResult.ListData.serializer(InviteInfoImpl.serializer())
+        
+        /**
+         * 构造 [InviteListRequest]
+         * @param guildId 服务器 id. 服务器 id 或者频道 id 必须填一个
+         * @param channelId 频道 id. 服务器 id 或者频道 id 必须填一个
+         * @param page 目标页数. 不小于0时有效。
+         * @param pageSize 每页数据数量. 不小于0时有效。
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID?, channelId: ID?, page: Int = -1, pageSize: Int = -1): InviteListRequest =
+            InviteListRequest(guildId, channelId, page, pageSize)
     }
-
+    
     init {
         Simbot.require(guildId != null || channelId != null) {
             "A guild id or channel id must exist"
         }
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<InviteInfo>>
         get() = serializer
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override fun ParametersBuilder.buildParameters() {
         appendIfNotnull("guild_id", guildId) { it.literal }
         appendIfNotnull("channel_id", channelId) { it.literal }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageDeleteRequest.kt
@@ -30,8 +30,17 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class DirectMessageDeleteRequest(private val msgId: ID) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("direct-message", "delete")
+public class DirectMessageDeleteRequest internal constructor(private val msgId: ID) : KookPostRequest<Unit>() {
+    public companion object Key : BaseKookApiRequestKey("direct-message", "delete") {
+    
+        /**
+         * 构造 [DirectMessageDeleteRequest].
+         * @param msgId 消息ID
+         */
+        @JvmStatic
+        public fun create(msgId: ID): DirectMessageDeleteRequest =
+            DirectMessageDeleteRequest(msgId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageListRequest.kt
@@ -54,9 +54,14 @@ public class DirectMessageListRequest private constructor(
     private val flag: MessageListFlag? = null,
 ) : KookGetRequest<KookApiResult.ListData<DirectMessageDetails>>() {
     public companion object Key : BaseKookApiRequestKey("direct-message", "list") {
+        /**
+         * 构造 [DirectMessageListRequest]
+         * @param chatCode 私信会话 Code。
+         * @param msgId 参考消息 id，不传则默认为最新的消息 id
+         * @param flag 查询模式，有三种模式可以选择。不传则默认查询最新的消息
+         */
         @JvmStatic
         @JvmOverloads
-        @JvmName("getInstanceByChatCode")
         public fun byChatCode(
             chatCode: ID,
             msgId: ID? = null,
@@ -66,10 +71,32 @@ public class DirectMessageListRequest private constructor(
                 chatCode = chatCode, targetId = null, msgId = msgId, flag = flag
             )
         }
-
+        
+        /**
+         * @suppress just use [byChatCode]
+         * @see byChatCode
+         */
+        @Deprecated(
+            "Just use byChatCode(...)", ReplaceWith(
+                "byChatCode(chatCode, msgId, flag)",
+                "love.forte.simbot.kook.api.message.DirectMessageListRequest.Key.byChatCode"
+            )
+        )
         @JvmStatic
         @JvmOverloads
-        @JvmName("getInstanceByTargetId")
+        public fun getInstanceByChatCode(
+            chatCode: ID, msgId: ID? = null, flag: MessageListFlag? = null
+        ): DirectMessageListRequest = byChatCode(chatCode, msgId, flag)
+    
+        /**
+         * 构造 [DirectMessageListRequest]
+         *
+         * @param targetId 目标用户 id，后端会自动创建会话。
+         * @param msgId 参考消息 id，不传则默认为最新的消息 id
+         * @param flag 查询模式，有三种模式可以选择。不传则默认查询最新的消息
+         */
+        @JvmStatic
+        @JvmOverloads
         public fun byTargetId(
             targetId: ID,
             msgId: ID? = null,
@@ -79,13 +106,33 @@ public class DirectMessageListRequest private constructor(
                 chatCode = null, targetId = targetId, msgId = msgId, flag = flag
             )
         }
+    
+        /**
+         * @suppress just use [byTargetId]
+         * @see byTargetId
+         */
+        @Deprecated(
+            "Just use byTargetId(...)",
+            ReplaceWith(
+                "byTargetId(targetId, msgId, flag)",
+                "love.forte.simbot.kook.api.message.DirectMessageListRequest.Key.byTargetId"
+            ),
+        )
+        @JvmStatic
+        @JvmOverloads
+        public fun getInstanceByTargetId(
+            targetId: ID,
+            msgId: ID? = null,
+            flag: MessageListFlag? = null,
+        ): DirectMessageListRequest = byTargetId(targetId, msgId, flag)
+        
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<DirectMessageDetails>>
         get() = KookApiResult.ListData.serializer(DirectMessageDetails.serializer)
-
+    
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun ParametersBuilder.buildParameters() {
         appendIfNotnull("chat_code", chatCode)
         appendIfNotnull("target_id", targetId)

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageUpdateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/DirectMessageUpdateRequest.kt
@@ -30,7 +30,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class DirectMessageUpdateRequest(
+public class DirectMessageUpdateRequest internal constructor(
 
     /**
      * 消息 id
@@ -47,7 +47,19 @@ public class DirectMessageUpdateRequest(
      */
     private val quote: ID?,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("direct-message", "update")
+    public companion object Key : BaseKookApiRequestKey("direct-message", "update") {
+    
+        /**
+         * 构建 [DirectMessageUpdateRequest]
+         * @param msgId 消息 id
+         * @param content 消息内容
+         * @param quote 回复某条消息的 msgId。如果为空，则代表删除回复，不传则无影响。
+         *
+         */
+        @JvmStatic
+        public fun create(msgId: ID, content: String, quote: ID?): DirectMessageUpdateRequest =
+            DirectMessageUpdateRequest(msgId, content, quote)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList
@@ -75,4 +87,4 @@ public fun MessageCreated.toDirectUpdate(
     content: String,
     quote: ID? = null
 ): DirectMessageUpdateRequest =
-    DirectMessageUpdateRequest(msgId, content, quote)
+    DirectMessageUpdateRequest.create(msgId, content, quote)

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageAddReactionRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageAddReactionRequest.kt
@@ -29,30 +29,59 @@ import love.forte.simbot.kook.api.KookPostRequest
  * [给某个消息添加回应](https://developer.kaiheila.cn/doc/http/message#%E7%BB%99%E6%9F%90%E4%B8%AA%E6%B6%88%E6%81%AF%E6%B7%BB%E5%8A%A0%E5%9B%9E%E5%BA%94)
  *
  */
-public class MessageAddReactionRequest(
+public class MessageAddReactionRequest internal constructor(
     /**
      * 	频道消息的id
      */
     private val msgId: ID,
     /**
-     *	emoji的id, 可以为 `Guild Emoji` 或者 `Emoji`
+     * emoji的id. 可以为 `Guild Emoji` 或者 `Emoji`
      */
     private val emoji: ID,
 ) : KookPostRequest<Unit>() {
+    @Deprecated("Use create(...)", ReplaceWith("MessageAddReactionRequest.create(msgId, emoji)"))
     public constructor(msgId: ID, emoji: love.forte.simbot.message.Emoji) : this(msgId, emoji.id)
+    
+    @Deprecated("Use create(...)", ReplaceWith("MessageAddReactionRequest.create(msgId, emoji)"))
     public constructor(msgId: ID, emoji: Emoji) : this(msgId, emoji.id)
-
-    public companion object Key : BaseKookApiRequestKey("message", "add-reaction")
-
+    
+    public companion object Key : BaseKookApiRequestKey("message", "add-reaction") {
+        
+        /**
+         * 构造 [MessageAddReactionRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji的id
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: ID): MessageAddReactionRequest = MessageAddReactionRequest(msgId, emoji)
+        
+        /**
+         * 构造 [MessageAddReactionRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: love.forte.simbot.message.Emoji): MessageAddReactionRequest =
+            create(msgId, emoji.id)
+        
+        /**
+         * 构造 [MessageAddReactionRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: Emoji): MessageAddReactionRequest = create(msgId, emoji.id)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList
     override fun createBody(): Any = Body(msgId, emoji)
-
+    
     @Serializable
     private data class Body(
         @SerialName("msg_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val msgId: ID,
         @Serializable(ID.AsCharSequenceIDSerializer::class) val emoji: ID
     )
-
-
+    
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageCreateRequest.kt
@@ -28,7 +28,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class MessageCreateRequest(
+public class MessageCreateRequest internal constructor(
     /**
      * 消息类型, 见[type], 不传默认为1, 代表文本类型。9代表 kmarkdown 消息, 10代表卡片消息。
      *
@@ -39,59 +39,75 @@ public class MessageCreateRequest(
      * @see MessageType
      */
     private val type: Int = MessageType.TEXT.type,
-
+    
     /**
      * 	目标频道 id
      */
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    private val targetId: ID,
-
+    @Serializable(ID.AsCharSequenceIDSerializer::class) private val targetId: ID,
+    
     /**
      * 	消息内容
      */
     private val content: String,
-
+    
     /**
      * 回复某条消息的 msgId
      */
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    private val quote: ID? = null,
-
+    @Serializable(ID.AsCharSequenceIDSerializer::class) private val quote: ID? = null,
+    
     /**
-     * nonce, 服务端不做处理, 原样返回
+     * 服务端不做处理, 原样返回
      */
     private val nonce: String? = null,
-
+    
     /**
      * 用户id,如果传了，代表该消息是临时消息，该消息不会存数据库，但是会在频道内只给该用户推送临时消息。用于在频道内针对用户的操作进行单独的回应通知等。
      */
-    @Serializable(ID.AsCharSequenceIDSerializer::class)
-    private val tempTargetId: ID? = null,
+    @Serializable(ID.AsCharSequenceIDSerializer::class) private val tempTargetId: ID? = null,
 ) : KookPostRequest<MessageCreated>() {
-    public companion object Key : BaseKookApiRequestKey("message", "create")
-
+    public companion object Key : BaseKookApiRequestKey("message", "create") {
+        
+        /**
+         * @param type 消息类型, 见[type], 不传默认为1, 代表文本类型。9代表 kmarkdown 消息, 10代表卡片消息。
+         * @param targetId 目标频道 id
+         * @param content 消息内容
+         * @param quote 回复某条消息的 msgId
+         * @param nonce 服务端不做处理, 原样返回
+         * @param tempTargetId 用户id,如果传了，代表该消息是临时消息，该消息不会存数据库，但是会在频道内只给该用户推送临时消息。
+         * 用于在频道内针对用户的操作进行单独的回应通知等。
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            type: Int = MessageType.TEXT.type,
+            targetId: ID,
+            content: String,
+            quote: ID? = null,
+            nonce: String? = null,
+            tempTargetId: ID? = null,
+        ): MessageCreateRequest = MessageCreateRequest(type, targetId, content, quote, nonce, tempTargetId)
+        
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out MessageCreated> get() = MessageCreated.serializer()
-
+    
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun createBody(): Any = Body(type, targetId, content, quote, nonce, tempTargetId)
-
-
+    
+    
     @Serializable
     private data class Body(
         val type: Int,
-        @SerialName("target_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val targetId: ID,
+        @SerialName("target_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val targetId: ID,
         val content: String,
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val quote: ID? = null,
+        @Serializable(ID.AsCharSequenceIDSerializer::class) val quote: ID? = null,
         val nonce: String? = null,
-        @SerialName("temp_target_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val tempTargetId: ID? = null,
+        @SerialName("temp_target_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val tempTargetId: ID? = null,
     )
-
+    
     /**
      * 将此api转化为 [DirectMessageCreateRequest].
      */
@@ -99,11 +115,12 @@ public class MessageCreateRequest(
     public fun toDirect(targetId: ID = this.targetId): DirectMessageCreateRequest {
         return DirectMessageCreateRequest.byTargetId(targetId, content, type, quote, nonce)
     }
+    
     /**
      * 将此api转化为 [DirectMessageCreateRequest].
      */
     public fun toDirectByChatCode(chatCode: ID): DirectMessageCreateRequest {
         return DirectMessageCreateRequest.byChatCode(chatCode, content, type, quote, nonce)
     }
-
+    
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageCreateRequest.kt
@@ -68,6 +68,7 @@ public class MessageCreateRequest internal constructor(
     public companion object Key : BaseKookApiRequestKey("message", "create") {
         
         /**
+         * 构造 [MessageCreateRequest]
          * @param type 消息类型, 见[type], 不传默认为1, 代表文本类型。9代表 kmarkdown 消息, 10代表卡片消息。
          * @param targetId 目标频道 id
          * @param content 消息内容

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageDeleteReactionRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageDeleteReactionRequest.kt
@@ -28,20 +28,66 @@ import love.forte.simbot.kook.api.KookPostRequest
  * [删除消息的某个回应](https://developer.kaiheila.cn/doc/http/message#%E5%88%A0%E9%99%A4%E6%B6%88%E6%81%AF%E7%9A%84%E6%9F%90%E4%B8%AA%E5%9B%9E%E5%BA%94)
  *
  */
-public class MessageDeleteReactionRequest(
+public class MessageDeleteReactionRequest internal constructor(
     private val msgId: ID,
     private val emoji: ID,
     private val userId: ID,
 ) : KookPostRequest<Unit>() {
+    @Deprecated(
+        "Use MessageDeleteReactionRequest.create(...)",
+        ReplaceWith("MessageDeleteReactionRequest.create(msgId. emoji, userId)")
+    )
     public constructor(msgId: ID, emoji: love.forte.simbot.message.Emoji, userId: ID) : this(msgId, emoji.id, userId)
+    
+    @Deprecated(
+        "Use MessageDeleteReactionRequest.create(...)",
+        ReplaceWith("MessageDeleteReactionRequest.create(msgId. emoji, userId)")
+    )
     public constructor(msgId: ID, emoji: Emoji, userId: ID) : this(msgId, emoji.id, userId)
-
-    public companion object Key : BaseKookApiRequestKey("message", "delete-reaction")
-
+    
+    public companion object Key : BaseKookApiRequestKey("message", "delete-reaction") {
+        
+        /**
+         * 构造 [MessageDeleteReactionRequest].
+         *
+         * @param msgId 消息id
+         * @param emoji emoji表情id
+         * @param userId 用户id
+         *
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: ID, userId: ID): MessageDeleteReactionRequest =
+            MessageDeleteReactionRequest(msgId, emoji, userId)
+        
+        /**
+         * 构造 [MessageDeleteReactionRequest].
+         *
+         * @param msgId 消息id
+         * @param emoji emoji表情
+         * @param userId 用户id
+         *
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: love.forte.simbot.message.Emoji, userId: ID): MessageDeleteReactionRequest =
+            create(msgId, emoji.id, userId)
+        
+        /**
+         * 构造 [MessageDeleteReactionRequest].
+         *
+         * @param msgId 消息id
+         * @param emoji emoji表情
+         * @param userId 用户id
+         *
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: Emoji, userId: ID): MessageDeleteReactionRequest =
+            create(msgId, emoji.id, userId)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList
     override fun createBody(): Any = Body(msgId, emoji, userId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("msg_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val msgId: ID,

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageDeleteRequest.kt
@@ -29,8 +29,16 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @param msgId 消息 id
  */
-public class MessageDeleteRequest(private val msgId: ID) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("message", "delete")
+public class MessageDeleteRequest internal constructor(private val msgId: ID) : KookPostRequest<Unit>() {
+    public companion object Key : BaseKookApiRequestKey("message", "delete") {
+    
+        /**
+         * 构建 [MessageDeleteRequest]
+         * @param msgId 消息ID
+         */
+        @JvmStatic
+        public fun create(msgId: ID): MessageDeleteRequest = MessageDeleteRequest(msgId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageListRequest.kt
@@ -30,29 +30,29 @@ import love.forte.simbot.kook.api.appendIfNotnull
  *
  * @author ForteScarlet
  */
-public class MessageListRequest(
+public class MessageListRequest internal constructor(
     /**
      * 频道 id
      */
     private val targetId: ID,
-
+    
     /**
      * 参考消息 id，不传则默认为最新的消息 id
      */
     private val msgId: ID? = null,
-
+    
     /**
      * 是否查询置顶消息（置顶消息只支持查询最新的消息）。
      */
     private val pin: Boolean = false,
-
+    
     /**
      * 查询模式，有三种模式可以选择。不传则默认查询最新的消息.
      *
      * @see MessageListFlag
      */
     private val flag: MessageListFlag? = null,
-
+    
     /**
      * 当前分页消息数量, 如果小于等于零则不提供此参数。服务器此参数默认 50
      */
@@ -60,14 +60,33 @@ public class MessageListRequest(
 ) : KookGetRequest<KookApiResult.ListData<ChannelMessageDetails>>() {
     public companion object Key : BaseKookApiRequestKey("message", "list") {
         private val serializer = KookApiResult.ListData.serializer(ChannelMessageDetailsImpl.serializer())
+        
+        /**
+         * 构造 [MessageListRequest]
+         * @param targetId 频道 id
+         * @param msgId 参考消息 id，不传则默认为最新的消息 id
+         * @param pin 是否查询置顶消息（置顶消息只支持查询最新的消息）。
+         * @param flag 查询模式，有三种模式可以选择。不传则默认查询最新的消息.
+         * @param pageSize 当前分页消息数量, 如果小于等于零则不提供此参数。服务器此参数默认 50
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            targetId: ID,
+            msgId: ID? = null,
+            pin: Boolean = false,
+            flag: MessageListFlag? = null,
+            pageSize: Int = -1
+        ): MessageListRequest =
+            MessageListRequest(targetId, msgId, pin, flag, pageSize)
     }
-
+    
     override val apiPaths: List<String>
         get() = apiPathList
-
+    
     override val resultDeserializer: DeserializationStrategy<out KookApiResult.ListData<ChannelMessageDetails>>
         get() = serializer
-
+    
     override fun ParametersBuilder.buildParameters() {
         append("target_id", targetId.toString())
         appendIfNotnull("msgId", msgId)

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageReactionListRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageReactionListRequest.kt
@@ -41,19 +41,44 @@ public class MessageReactionListRequest(
 ) : KookGetRequest<List<MessageReactor>>() {
     public constructor(msgId: ID, emoji: love.forte.simbot.message.Emoji) : this(msgId, emoji.id)
     public constructor(msgId: ID, emoji: Emoji) : this(msgId, emoji.id)
-
+    
     public companion object Key : BaseKookApiRequestKey("message", "reaction-list") {
         private val serializer = ListSerializer(MessageReactor.serializer())
+        
+        /**
+         * 构建 [MessageReactionListRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji的id
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: ID): MessageReactionListRequest = MessageReactionListRequest(msgId, emoji)
+        
+        /**
+         * 构建 [MessageReactionListRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: love.forte.simbot.message.Emoji): MessageReactionListRequest =
+            create(msgId, emoji.id)
+        
+        /**
+         * 构建 [MessageReactionListRequest]
+         * @param msgId 频道消息的id
+         * @param emoji emoji
+         */
+        @JvmStatic
+        public fun create(msgId: ID, emoji: Emoji): MessageReactionListRequest = create(msgId, emoji.id)
     }
-
+    
     override val resultDeserializer: DeserializationStrategy<out List<MessageReactor>> get() = serializer
     override val apiPaths: List<String> get() = apiPathList
-
+    
     override fun ParametersBuilder.buildParameters() {
         append("msg_id", msgId.toString())
         append("emoji", emoji.toString())
     }
-
+    
 }
 
 
@@ -62,22 +87,22 @@ public class MessageReactionListRequest(
  */
 @Serializable
 public class MessageReactor @ApiResultType constructor(
-
+    
     /**
      * 用户的id
      */
     public val id: CharSequenceID,
-
+    
     /**
      * 用户的名称
      */
     public val username: String,
-
+    
     /**
      * 用户在服务器内的呢称
      */
     public val nickname: String,
-
+    
     /**
      * 用户名的认证数字，用户名正常为：user_name#identify_num
      */
@@ -91,12 +116,12 @@ public class MessageReactor @ApiResultType constructor(
      * 用户的状态, 0代表正常，10代表被封禁
      */
     public val status: Int,
-
+    
     /**
      * 用户的头像的url地址
      */
     public val avatar: String,
-
+    
     /**
      * 	用户是否为机器人
      */
@@ -112,7 +137,7 @@ public class MessageReactor @ApiResultType constructor(
         public const val STATUS_NORMAL: Int = 0
         public const val STATUS_BAN: Int = 10
     }
-
+    
 }
 
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageUpdateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageUpdateRequest.kt
@@ -30,7 +30,7 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * *无返回参数*
  */
-public class MessageUpdateRequest(
+public class MessageUpdateRequest internal constructor(
     /**
      * 消息 id
      */
@@ -103,4 +103,4 @@ public fun MessageCreated.toUpdate(
     content: String,
     quote: ID? = null
 ): MessageUpdateRequest =
-    MessageUpdateRequest(msgId, content, quote)
+    MessageUpdateRequest.create(msgId, content, quote)

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageUpdateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageUpdateRequest.kt
@@ -35,30 +35,50 @@ public class MessageUpdateRequest(
      * 消息 id
      */
     private val msgId: ID,
-
+    
     /**
      * 消息内容
      */
     private val content: String,
-
+    
     /**
      * 回复某条消息的 msgId。如果为空
      * （为空大概指空字符串：`""`，可以使用 [CharSequenceID.EMPTY] 或者 `"".ID` ），
      * 则代表删除回复，不传则无影响。
      */
     private val quote: ID? = null,
-
+    
     /**
      * 用户 id，针对特定用户临时更新消息，必须是正常消息才能更新。与发送临时消息概念不同，但同样不保存数据库。
      */
     private val tempTargetId: ID? = null,
 ) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("message", "update")
-
+    public companion object Key : BaseKookApiRequestKey("message", "update") {
+    
+        /**
+         *
+         * @param msgId 消息 id
+         * @param content 消息内容
+         * @param quote 回复某条消息的 msgId。如果为空
+         * （为空大概指空字符串：`""`，可以使用 [CharSequenceID.EMPTY] 或者 `"".ID` ）
+         * 则代表删除回复，不传则无影响。
+         * @param tempTargetId 用户 id，针对特定用户临时更新消息，必须是正常消息才能更新。与发送临时消息概念不同，但同样不保存数据库。
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            msgId: ID,
+            content: String,
+            quote: ID? = null,
+            tempTargetId: ID? = null,
+        ): MessageUpdateRequest =
+            MessageUpdateRequest(msgId, content, quote, tempTargetId)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList
     override fun createBody(): Any = Body(msgId, content, quote, tempTargetId)
-
+    
     @Serializable
     private data class Body(
         @SerialName("msg_id")

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageViewRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/message/MessageViewRequest.kt
@@ -27,8 +27,16 @@ import love.forte.simbot.kook.api.KookGetRequest
  * [获取频道聊天消息详情](https://developer.kaiheila.cn/doc/http/message#%E8%8E%B7%E5%8F%96%E9%A2%91%E9%81%93%E8%81%8A%E5%A4%A9%E6%B6%88%E6%81%AF%E8%AF%A6%E6%83%85)
  * @author ForteScarlet
  */
-public class MessageViewRequest(private val msgId: ID) : KookGetRequest<ChannelMessageDetails>() {
-    public companion object Key : BaseKookApiRequestKey("message", "view")
+public class MessageViewRequest internal constructor(private val msgId: ID) : KookGetRequest<ChannelMessageDetails>() {
+    public companion object Key : BaseKookApiRequestKey("message", "view") {
+    
+        /**
+         * 构造 [MessageViewRequest]
+         * @param msgId 消息ID
+         */
+        @JvmStatic
+        public fun create(msgId: ID): MessageViewRequest = MessageViewRequest(msgId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out ChannelMessageDetails>
         get() = ChannelMessageDetailsImpl.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/user/UserViewRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/user/UserViewRequest.kt
@@ -30,11 +30,23 @@ import love.forte.simbot.literal
  * 查询用户信息
  * @author ForteScarlet
  */
-public class UserViewRequest(
+public class UserViewRequest internal constructor(
     private val userId: ID,
     private val guildId: ID,
 ) : KookGetRequest<User>() {
-    public companion object Key : BaseKookApiRequestKey("user", "view")
+    public companion object Key : BaseKookApiRequestKey("user", "view") {
+    
+        /**
+         * 构造 [UserViewRequest].
+         *
+         * @param userId 用户id
+         * @param guildId 频道服务器id
+         *
+         */
+        @JvmStatic
+        public fun create(userId: ID, guildId: ID): UserViewRequest = UserViewRequest(userId, guildId)
+        
+    }
 
     override val resultDeserializer: DeserializationStrategy<out User>
         get() = UserImpl.serializer()

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatCreateRequest.kt
@@ -30,8 +30,17 @@ import love.forte.simbot.kook.api.KookPostRequest
  *
  * @author ForteScarlet
  */
-public class UserChatCreateRequest(private val targetId: ID) : KookPostRequest<UserChatView>() {
-    public companion object Key : BaseKookApiRequestKey("user-chat", "create")
+public class UserChatCreateRequest internal constructor(private val targetId: ID) : KookPostRequest<UserChatView>() {
+    public companion object Key : BaseKookApiRequestKey("user-chat", "create") {
+    
+        /**
+         * 构造 [UserChatCreateRequest].
+         *
+         * @param targetId 目标id
+         */
+        @JvmStatic
+        public fun create(targetId: ID): UserChatCreateRequest = UserChatCreateRequest(targetId)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out UserChatView> get() = UserChatViewImpl.serializer()
     override val apiPaths: List<String> get() = apiPathList

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatDeleteRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatDeleteRequest.kt
@@ -32,8 +32,18 @@ import love.forte.simbot.kook.api.KookPostRequest
  * @param chatCode 删除目标会话的ID
  * @author ForteScarlet
  */
-public class UserChatDeleteRequest(private val chatCode: ID) : KookPostRequest<Unit>() {
-    public companion object Key : BaseKookApiRequestKey("user-chat", "delete")
+public class UserChatDeleteRequest internal constructor(private val chatCode: ID) : KookPostRequest<Unit>() {
+    public companion object Key : BaseKookApiRequestKey("user-chat", "delete") {
+    
+        /**
+         * 构造 [UserChatDeleteRequest].
+         *
+         * @param chatCode 目标会话id
+         *
+         */
+        @JvmStatic
+        public fun create(chatCode: ID): UserChatDeleteRequest = UserChatDeleteRequest(chatCode)
+    }
 
     override val resultDeserializer: DeserializationStrategy<out Unit> get() = Unit.serializer()
     override val apiPaths: List<String> get() = apiPathList

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatViewRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/userchat/UserChatViewRequest.kt
@@ -35,8 +35,18 @@ import love.forte.simbot.literal
  * @param chatCode 会话ID
  * @author ForteScarlet
  */
-public class UserChatViewRequest(private val chatCode: ID) : KookGetRequest<UserChatView>() {
-    public companion object Key : BaseKookApiRequestKey("user-chat", "view")
+public class UserChatViewRequest internal constructor(private val chatCode: ID) : KookGetRequest<UserChatView>() {
+    public companion object Key : BaseKookApiRequestKey("user-chat", "view") {
+    
+        /**
+         * 构造 [UserChatViewRequest].
+         *
+         * @param chatCode 目标会话id
+         *
+         */
+        @JvmStatic
+        public fun create(chatCode: ID): UserChatViewRequest = UserChatViewRequest(chatCode)
+    }
     
     override val resultDeserializer: DeserializationStrategy<out UserChatView>
         get() = UserChatViewImpl.serializer()

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookChannel.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/KookChannel.kt
@@ -144,7 +144,7 @@ public interface KookChannel : Channel, KookComponentDefinition<KkChannel> {
         nonce: String?,
         tempTargetId: ID?,
     ): KookMessageReceipt {
-        val request = MessageCreateRequest(type, source.id, content, quote, nonce, tempTargetId)
+        val request = MessageCreateRequest.create(type, source.id, content, quote, nonce, tempTargetId)
         return send(request)
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookChannelChangedEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookChannelChangedEvent.kt
@@ -271,7 +271,7 @@ public abstract class KookMessagePinEvent<Body : ChannelEventExtraBody> :
     @JvmBlocking
     @JvmAsync
     public suspend fun queryMsg(): MessageContent {
-        val messageView = MessageViewRequest(msgId).requestDataBy(bot)
+        val messageView = MessageViewRequest.create(msgId).requestDataBy(bot)
         return messageView.toContent(bot)
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
@@ -304,7 +304,7 @@ private suspend fun KookComponentBotImpl.findUserInGuilds(userId: ID, guildIds: 
         .mapNotNull { id -> internalGuild(id) }
         .mapNotNull { g -> g.getInternalMember(userId) }
         .firstOrNull() ?: userId.let {
-        UserViewRequest(userId, guildIds.first()).requestDataBy(bot)
+        UserViewRequest.create(userId, guildIds.first()).requestDataBy(bot)
     }
 }
 

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
@@ -102,7 +102,7 @@ internal class KookChannelImpl private constructor(
         return when (message) {
             is KookReceiveMessageContent -> {
                 val source = message.source
-                MessageCreateRequest(
+                MessageCreateRequest.create(
                     type = source.type.type,
                     targetId = this.id,
                     content = source.content,
@@ -114,7 +114,7 @@ internal class KookChannelImpl private constructor(
             
             is KookChannelMessageDetailsContent -> {
                 val details = message.details
-                MessageCreateRequest(
+                MessageCreateRequest.create(
                     type = details.type,
                     targetId = this.id,
                     content = details.content,

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -381,7 +381,7 @@ internal class KookComponentBotImpl(
                         // query user info.
                         val guild = internalGuild(this.targetId) ?: return
                         val userInfo =
-                            UserViewRequest(guild.id, body.userId).requestDataBy(this@KookComponentBotImpl)
+                            UserViewRequest.create(guild.id, body.userId).requestDataBy(this@KookComponentBotImpl)
                         val userModel = userInfo.toModel()
                         
                         guild.internalMembers.compute(body.userId.literal) { _, current ->

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -502,7 +502,7 @@ internal class KookComponentBotImpl(
                     }
                     // bot加入了某服务器
                     is SelfJoinedGuildEventBody -> {
-                        val guildInfo = GuildViewRequest(body.guildId).requestDataBy(this@KookComponentBotImpl)
+                        val guildInfo = GuildViewRequest.create(body.guildId).requestDataBy(this@KookComponentBotImpl)
                         val guildModel = guildInfo.toModel()
                         val newGuild = guildModel.toKookGuild(this@KookComponentBotImpl)
                         internalGuilds.merge(guildInfo.id.literal, newGuild) { old, cur ->

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -431,7 +431,7 @@ internal class KookComponentBotImpl(
                         
                         internalGuilds[guildId]?.also { guild ->
                             // query channel info.
-                            val channelView = ChannelViewRequest(channelId).requestDataBy(this@KookComponentBotImpl)
+                            val channelView = ChannelViewRequest.create(channelId).requestDataBy(this@KookComponentBotImpl)
                             val channelModel = channelView.toModel()
                             guild.computeMergeChannelModel(channelModel)
                         }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -144,7 +144,7 @@ internal class KookComponentBotImpl(
             var page = 1
             do {
                 bot.logger.debug("Sync guild data ... page {}", page)
-                val guildsResult = GuildListRequest(page = page).requestDataBy(this@KookComponentBotImpl)
+                val guildsResult = GuildListRequest.create(page = page).requestDataBy(this@KookComponentBotImpl)
                 val guilds = guildsResult.items
                 bot.logger.debug("{} guild data synchronized in page {}", guilds.size, page)
                 guilds.forEach {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -305,7 +305,7 @@ internal class KookComponentBotImpl(
     
     // region friend api
     override suspend fun contact(id: ID): KookUserChatImpl {
-        val chat = UserChatCreateRequest(id).requestDataBy(bot)
+        val chat = UserChatCreateRequest.create(id).requestDataBy(bot)
         return KookUserChatImpl(this, chat.toModel())
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookComponentBotImpl.kt
@@ -335,7 +335,7 @@ internal class KookComponentBotImpl(
      */
     @JvmSynthetic
     override suspend fun uploadAsset(resource: Resource, type: Int): KookSimpleAssetMessage {
-        val asset = AssetCreateRequest(resource).requestDataBy(this)
+        val asset = AssetCreateRequest.create(resource).requestDataBy(this)
         return asset.asMessage(type)
     }
     
@@ -354,7 +354,7 @@ internal class KookComponentBotImpl(
 
     
     override suspend fun uploadAssetImage(resource: Resource): KookAssetImage {
-        val asset = AssetCreateRequest(resource).requestDataBy(this)
+        val asset = AssetCreateRequest.create(resource).requestDataBy(this)
         return asset.asImage()
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
@@ -249,7 +249,7 @@ internal class KookGuildImpl private constructor(
                 delay(batchDelay)
             }
             baseBot.logger.debug("Sync member data ... page {}", page)
-            val usersResult = GuildUserListRequest(guildId = guildId, page = page).requestDataBy(baseBot)
+            val usersResult = GuildUserListRequest.create(guildId = guildId, page = page).requestDataBy(baseBot)
             val users = usersResult.items
             baseBot.logger.debug("{} member data synced in page {}", users.size, page)
             users.forEach {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
@@ -121,7 +121,7 @@ internal class KookGuildImpl private constructor(
         this.lastOwnerMember = owner ?: KookGuildMemberImpl(
             baseBot,
             this,
-            UserViewRequest(ownerId, guildId).requestDataBy(baseBot).toModel()
+            UserViewRequest.create(ownerId, guildId).requestDataBy(baseBot).toModel()
         )
         initTimestamp = System.currentTimeMillis()
     }
@@ -141,7 +141,7 @@ internal class KookGuildImpl private constructor(
                 val member = KookGuildMemberImpl(
                     baseBot,
                     this@KookGuildImpl,
-                    UserViewRequest(ownerId, source.id).requestDataBy(baseBot).toModel()
+                    UserViewRequest.create(ownerId, source.id).requestDataBy(baseBot).toModel()
                 )
                 internalMembers.merge(id, member) { _, cur -> cur }!!
             }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildImpl.kt
@@ -230,7 +230,7 @@ internal class KookGuildImpl private constructor(
                 delay(batchDelay)
             }
             baseBot.logger.debug("Sync channel data ... page {}", page)
-            val result = ChannelListRequest(guildId = guildId, type = type, page = page).requestDataBy(baseBot)
+            val result = ChannelListRequest.create(guildId = guildId, type = type, page = page).requestDataBy(baseBot)
             val channels = result.items
             baseBot.logger.debug("{} channel data synced in page {}", channels.size, page)
             channels.forEach {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildInternalOperation.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildInternalOperation.kt
@@ -107,7 +107,7 @@ internal suspend fun KookGuildImpl.computeMergeChannelModel(
 
 
 internal suspend fun KookGuildImpl.queryChannelModel(channelId: ID): ChannelModel? {
-    val model = ChannelViewRequest(channelId).let { req ->
+    val model = ChannelViewRequest.create(channelId).let { req ->
         val result = req.requestBy(baseBot).takeIf { it.isSuccess }
         result?.parseData(baseBot.sourceBot.configuration.decoder, req.resultDeserializer)
     }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildMemberImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildMemberImpl.kt
@@ -68,7 +68,7 @@ internal class KookGuildMemberImpl(
     // region mute相关
     override suspend fun unmute(type: Int): Boolean {
         // do unmute
-        val result = GuildMuteDeleteRequest(_guild.id, source.id, type).requestBy(bot)
+        val result = GuildMuteDeleteRequest.create(_guild.id, source.id, type).requestBy(bot)
         return result.isSuccess.also { success ->
             if (success) {
                 muteLock.withLock {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildMemberImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookGuildMemberImpl.kt
@@ -83,7 +83,7 @@ internal class KookGuildMemberImpl(
     override suspend fun mute(durationMillis: Long, type: Int): Boolean {
         Simbot.require(durationMillis > 0) { "Duration millis must > 0, but $durationMillis" }
         // do mute
-        val result = GuildMuteCreateRequest(_guild.id, source.id, type).requestBy(bot)
+        val result = GuildMuteCreateRequest.create(_guild.id, source.id, type).requestBy(bot)
         return result.isSuccess.also { success ->
             if (durationMillis > 0 && success) {
                 val scope: CoroutineScope = this

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookUserChatImpl.kt
@@ -98,6 +98,6 @@ internal class KookUserChatImpl(
     }
     
     override suspend fun delete(): Boolean {
-        return UserChatDeleteRequest(id).requestBy(bot).isSuccess
+        return UserChatDeleteRequest.create(id).requestBy(bot).isSuccess
     }
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageEventImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageEventImpl.kt
@@ -95,7 +95,7 @@ internal class KookContactMessageEventImpl(
     private var userChatView: KookUserChatImpl? = null
     
     private suspend fun userChatView(): KookUserChatImpl {
-        val view = UserChatCreateRequest(sourceEvent.authorId).requestDataBy(bot)
+        val view = UserChatCreateRequest.create(sourceEvent.authorId).requestDataBy(bot)
         return KookUserChatImpl(bot, view)
     }
     
@@ -161,7 +161,7 @@ internal class KookBotSelfMessageEventImpl(
     
     
     private val userChatView = lazyValue {
-        val view = UserChatCreateRequest(sourceEvent.authorId).requestDataBy(bot)
+        val view = UserChatCreateRequest.create(sourceEvent.authorId).requestDataBy(bot)
         KookUserChatImpl(bot, view.toModel())
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookChannelMessageDetailsContent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookChannelMessageDetailsContent.kt
@@ -76,7 +76,7 @@ public data class KookChannelMessageDetailsContent(
      *
      */
     override suspend fun delete(): Boolean {
-        MessageDeleteRequest(messageId).requestDataBy(bot)
+        MessageDeleteRequest.create(messageId).requestDataBy(bot)
         return true
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessageCreatedReceipt.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessageCreatedReceipt.kt
@@ -95,7 +95,7 @@ public class KookMessageCreatedReceipt(
      */
     @JvmSynthetic
     override suspend fun delete(): Boolean {
-        val request = if (isDirect) DirectMessageDeleteRequest.create(id) else MessageDeleteRequest(id)
+        val request = if (isDirect) DirectMessageDeleteRequest.create(id) else MessageDeleteRequest.create(id)
         return request.requestBy(bot).isSuccess
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessageCreatedReceipt.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessageCreatedReceipt.kt
@@ -95,7 +95,7 @@ public class KookMessageCreatedReceipt(
      */
     @JvmSynthetic
     override suspend fun delete(): Boolean {
-        val request = if (isDirect) DirectMessageDeleteRequest(id) else MessageDeleteRequest(id)
+        val request = if (isDirect) DirectMessageDeleteRequest.create(id) else MessageDeleteRequest(id)
         return request.requestBy(bot).isSuccess
     }
     

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
@@ -43,12 +43,12 @@ import kotlin.coroutines.suspendCoroutine
 public object KookMessages {
     
     /**
-     * 当at(mention)的目标为用户时，[At.atType] 所使用的值。[AT_TYPE_USER] 也是 [At.atType] 的默认值。
+     * 当at(mention)的目标为用户时，[At.type] 所使用的值。[AT_TYPE_USER] 也是 [At.atType] 的默认值。
      */
     public const val AT_TYPE_USER: String = "user"
     
     /**
-     * 当at(mention)的目标为角色时，[At.atType] 所使用的值。
+     * 当at(mention)的目标为角色时，[At.type] 所使用的值。
      */
     public const val AT_TYPE_ROLE: String = "role"
     
@@ -194,7 +194,7 @@ private suspend fun Message.Element<*>.elementToRequestOrNull(
                     else -> throw SimbotIllegalArgumentException("Unknown attachment type: $attachmentType")
                 }
                 
-                val createRequest = AssetCreateRequest(URL(attachment.url).toResource(attachment.name))
+                val createRequest = AssetCreateRequest.create(URL(attachment.url).toResource(attachment.name))
                 val asset = createRequest.requestDataBy(bot)
                 
                 request(type, asset.url)
@@ -207,7 +207,7 @@ private suspend fun Message.Element<*>.elementToRequestOrNull(
         
         // 需要上传的图片
         is ResourceImage -> {
-            val asset = AssetCreateRequest(resource()).requestDataBy(bot)
+            val asset = AssetCreateRequest.create(resource()).requestDataBy(bot)
             request(MessageType.IMAGE.type, asset.url)
         }
         

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
@@ -151,7 +151,7 @@ private suspend fun Message.Element<*>.elementToRequestOrNull(
     tempTargetId: ID? = null,
 ): KookApiRequest<*>? {
     fun request(type: Int, content: String): MessageCreateRequest {
-        return MessageCreateRequest(
+        return MessageCreateRequest.create(
             type = type,
             targetId = targetId,
             content = content,

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
@@ -44,7 +44,7 @@ private fun createRequest(
     nonce: String?,
     tempTargetId: ID?,
 ): KookApiRequest<*> {
-    return MessageCreateRequest(
+    return MessageCreateRequest.create(
         type = type,
         targetId = targetId,
         content = content,
@@ -136,7 +136,7 @@ private suspend fun Message.send0(
     var quote0 = quote
     fun doRequest(type: Int, content: String): KookApiRequest<*> {
         return when (directType) {
-            NOT_DIRECT -> MessageCreateRequest(
+            NOT_DIRECT -> MessageCreateRequest.create(
                 type = type,
                 targetId = targetId,
                 content = content,

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
@@ -313,7 +313,7 @@ private suspend inline fun Message.Element<*>.elementToRequest(
                 // TODO just re-upload and send, waiting for fix.
                 //  see https://github.com/simple-robot/simbot-component-kook/issues/75
                 
-                val createRequest = AssetCreateRequest(URL(message.attachment.url).toResource(message.attachment.name))
+                val createRequest = AssetCreateRequest.create(URL(message.attachment.url).toResource(message.attachment.name))
                 val asset = createRequest.requestDataBy(bot)
                 
                 doRequest(type.type, asset.url)
@@ -326,7 +326,7 @@ private suspend inline fun Message.Element<*>.elementToRequest(
         
         // 需要上传的图片
         is ResourceImage -> {
-            val asset = AssetCreateRequest(message.resource()).requestDataBy(bot)
+            val asset = AssetCreateRequest.create(message.resource()).requestDataBy(bot)
             doRequest(MessageType.IMAGE.type, asset.url)
         }
         

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
@@ -121,7 +121,7 @@ public class KookReceiveMessageContent(
      */
     override suspend fun delete(): Boolean {
         val api = if (isDirect) {
-            DirectMessageDeleteRequest(messageId)
+            DirectMessageDeleteRequest.create(messageId)
         } else {
             MessageDeleteRequest(messageId)
         }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookReceiveMessageContent.kt
@@ -123,7 +123,7 @@ public class KookReceiveMessageContent(
         val api = if (isDirect) {
             DirectMessageDeleteRequest.create(messageId)
         } else {
-            MessageDeleteRequest(messageId)
+            MessageDeleteRequest.create(messageId)
         }
         api.requestDataBy(bot)
         

--- a/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBot.kt
+++ b/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/KookBot.kt
@@ -24,6 +24,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.CharSequenceID
 import love.forte.simbot.ID
 import love.forte.simbot.LoggerContainer
+import love.forte.simbot.kook.api.KookApiRequestor
 import love.forte.simbot.kook.api.user.Me
 import love.forte.simbot.kook.api.user.MeRequest
 import love.forte.simbot.kook.api.user.OfflineRequest
@@ -38,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * @author ForteScarlet
  */
-public interface KookBot : CoroutineScope, LoggerContainer {
+public interface KookBot : CoroutineScope, LoggerContainer, KookApiRequestor {
     override val coroutineContext: CoroutineContext
     override val logger: Logger
 
@@ -61,8 +62,19 @@ public interface KookBot : CoroutineScope, LoggerContainer {
      * 此实例代表的用于进行API请求（xxxRequest）的http client。
      */
     public val httpClient: HttpClient
-
-
+    
+    /**
+     * @see httpClient
+     */
+    override val client: HttpClient
+        get() = httpClient
+    
+    /**
+     * @see ticket
+     */
+    override val authorization: String
+        get() = ticket.authorization
+    
     /**
      * 添加一个事件的前置处理器。
      *


### PR DESCRIPTION
调整会将所有的API类型的主构造变更为 `internal` 级别（理论上二进制兼容但源码不兼容），并在后续一段时间后变更为 `private` 级别。

例如：

```kotlin
// val userViewRequest = UserViewRequest(113.ID, 223.ID)
// 👇 变更为

val userViewRequest = UserViewRequest.create(123.ID, 223.ID)
```