### PR TITLE
API请求不再强制要求 HttpClient 安装 ContentNegotiation 插件

### DIFF
--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -32,6 +32,3 @@ jobs:
             test
             --info 
             --warning-mode all
-            --build-cache
-            -Porg.gradle.jvmargs="-Xmx4g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
-            -Porg.gradle.daemon=false

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -63,7 +63,7 @@ object P : ProjectDetail() {
         0, 0
     )
 
-    private val alphaSuffix = v("alpha", 5)
+    private val alphaSuffix = v("alpha", 6)
 
     override val version: Version = baseVersion - alphaSuffix
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,8 @@
 kotlin.code.style=official
+kotlin.js.generate.executable.default=false
+kotlin.mpp.stability.nowarn=true
+kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+
+org.gradle.daemon=false
+org.gradle.parallel=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,6 @@
 rootProject.name = "simbot-component-kook"
 
 include("simbot-component-kook-api")
-include("simbot-component-kook-api-multi")
+//include("simbot-component-kook-api-multi")
 include("simbot-component-kook-stdlib")
 include("simbot-component-kook-core")

--- a/simbot-component-kook-api/build.gradle.kts
+++ b/simbot-component-kook-api/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     api(libs.ktor.client.core)
     api(libs.ktor.client.cio)
     api(libs.ktor.client.serialization)
+    api(libs.ktor.client.contentNegotiation)
     api(libs.kotlinx.serialization.json)
     compileOnly(libs.jetbrains.annotations)
 }

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/KookApiRequest.kt
@@ -21,13 +21,18 @@ package love.forte.simbot.kook.api
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.client.utils.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
 import love.forte.simbot.Api4J
 import love.forte.simbot.InternalSimbotApi
 import love.forte.simbot.kook.Kook
@@ -74,9 +79,10 @@ public abstract class KookApiRequest<T> : API<KookApiRequestor, T> {
 
     /**
      * 可以为 [request] 提供更多行为的函数，例如提供body、重置contentType等。
+     *
+     * 如果实现 [KookPostRequest] 则不需要设置body，会自动检测并设置。
      */
     protected open fun HttpRequestBuilder.requestFinishingAction() {
-        headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
     }
 
     /**
@@ -151,6 +157,31 @@ public abstract class KookApiRequest<T> : API<KookApiRequestor, T> {
         }
 
         val response = requestForResponse(client, authorization) {
+            headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
+            if (this@KookApiRequest is KookPostRequest) {
+                when (val body = this@KookApiRequest.body) {
+                    null -> setBody(EmptyContent)
+                    is OutgoingContent -> setBody(body)
+                    else -> {
+                        if (client.pluginOrNull(ContentNegotiation) != null) {
+                            setBody(body)
+                        } else {
+                            try {
+                                val ser = guessSerializer(body, DEFAULT_JSON.serializersModule)
+                                val bodyJson = DEFAULT_JSON.encodeToString(ser, body)
+                                setBody(bodyJson)
+                            } catch (e: Throwable) {
+                                try {
+                                    setBody(body)
+                                } catch (e0: Throwable) {
+                                    e0.addSuppressed(e)
+                                    throw e0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             requestFinishingAction()
         }
 
@@ -290,7 +321,10 @@ public abstract class KookApiRequest<T> : API<KookApiRequestor, T> {
         internal val DEFAULT_JSON = Json {
             isLenient = true
             ignoreUnknownKeys = true
-            encodeDefaults = true
+            allowSpecialFloatingPointValues = true
+            allowStructuredMapKeys = true
+            prettyPrint = false
+            useArrayPolymorphism = false
         }
 
         internal val defaultRequestPostChecker: Consumer<HttpResponse> = Consumer {}
@@ -412,12 +446,7 @@ public abstract class KookPostRequest<T>(
      */
     protected open fun createBody(): Any? = null
 
-    /**
-     * 通过 [body] 构建提供 body 属性。
-     */
     override fun HttpRequestBuilder.requestFinishingAction() {
-        headers[HttpHeaders.ContentType] = ContentType.Application.Json.toString()
-        setBody(this@KookPostRequest.body ?: EmptyContent)
     }
 
 
@@ -450,3 +479,57 @@ public inline fun <reified T> ParametersBuilder.appendIfNotnull(
         append(name, toStringBlock(v))
     }
 }
+
+
+
+//region Ktor ContentNegotiation guessSerializer
+// see KotlinxSerializationJsonExtensions.kt
+// see SerializerLookup.kt
+
+@Suppress("UNCHECKED_CAST")
+private fun guessSerializer(value: Any?, module: SerializersModule): KSerializer<Any> = when (value) {
+    null -> String.serializer().nullable
+    is List<*> -> ListSerializer(value.elementSerializer(module))
+    is Array<*> -> value.firstOrNull()?.let { guessSerializer(it, module) } ?: ListSerializer(String.serializer())
+    is Set<*> -> SetSerializer(value.elementSerializer(module))
+    is Map<*, *> -> {
+        val keySerializer = value.keys.elementSerializer(module)
+        val valueSerializer = value.values.elementSerializer(module)
+        MapSerializer(keySerializer, valueSerializer)
+    }
+
+    else -> {
+        @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+        module.getContextual(value::class) ?: value::class.serializer()
+    }
+} as KSerializer<Any>
+
+
+@OptIn(ExperimentalSerializationApi::class)
+private fun Collection<*>.elementSerializer(module: SerializersModule): KSerializer<*> {
+    val serializers: List<KSerializer<*>> =
+        filterNotNull().map { guessSerializer(it, module) }.distinctBy { it.descriptor.serialName }
+
+    if (serializers.size > 1) {
+        error(
+            "Serializing collections of different element types is not yet supported. " +
+                    "Selected serializers: ${serializers.map { it.descriptor.serialName }}",
+        )
+    }
+
+    val selected = serializers.singleOrNull() ?: String.serializer()
+
+    if (selected.descriptor.isNullable) {
+        return selected
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    selected as KSerializer<Any>
+
+    if (any { it == null }) {
+        return selected.nullable
+    }
+
+    return selected
+}
+//endregion

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/asset/AssetCreateRequest.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/api/asset/AssetCreateRequest.kt
@@ -112,8 +112,8 @@ public class AssetCreateRequest internal constructor(
             }
         }
     }
-    
-    override fun createBody(): Any {
+
+    override fun createBody(): MultiPartFormDataContent {
         return MultiPartFormDataContent(
             formData {
                 

--- a/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/internal/KookBotImpl.kt
+++ b/simbot-component-kook-stdlib/src/main/kotlin/love/forte/simbot/kook/internal/KookBotImpl.kt
@@ -20,8 +20,10 @@ package love.forte.simbot.kook.internal
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
@@ -132,6 +134,11 @@ internal class KookBotImpl(
                 engine { configEngine(engineConfig) }
             }
 
+            // ContentNegotiation
+            install(ContentNegotiation) {
+                json()
+            }
+
             // http request timeout
             configuration.timeout?.also { timeoutConfig ->
                 install(HttpTimeout) {
@@ -146,6 +153,10 @@ internal class KookBotImpl(
             // engine config
             configuration.wsEngineConfig?.also { engineConfig ->
                 engine { configEngine(engineConfig) }
+            }
+            // ContentNegotiation
+            install(ContentNegotiation) {
+                json()
             }
 
             WebSockets {
@@ -165,8 +176,10 @@ internal class KookBotImpl(
             }
 
             else -> {
-                logger.debug("API engine use ServiceLoader.")
-                HttpClient { configApiClient() }
+                logger.debug("API engine load by ServiceLoader.")
+                HttpClient { configApiClient() }.also {
+                    logger.debug("API engine used: {}", it.engine)
+                }
             }
         }
 
@@ -791,6 +804,7 @@ internal class KookBotImpl(
             get() = atomicSn.get()
         override val isCompress: Boolean
             get() = this@KookBotImpl.isCompress
+
         @Deprecated("Will be removed in the future")
         override val bot: KookBot
             get() = this@KookBotImpl


### PR DESCRIPTION
但是仍建议使用它，并且在内部使用的（比如bot使用的）client依旧会安装。

fix https://github.com/simple-robot/simpler-robot/issues/681