### PR TITLE
尝试修复 `Card` 反序列化异常的问题

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -63,7 +63,7 @@ object P : ProjectDetail() {
         0, 0
     )
 
-    private val alphaSuffix = v("alpha", 6)
+    private val alphaSuffix = v("alpha", 7)
 
     override val version: Version = baseVersion - alphaSuffix
 

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/objects/Card.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/objects/Card.kt
@@ -19,7 +19,10 @@
 
 package love.forte.simbot.kook.objects
 
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.listSerialDescriptor
@@ -489,10 +492,12 @@ public sealed class CardModule {
      */
     @Serializable
     @SerialName(Header.TYPE)
-    public data class Header(public val text: String) : CardModule() {
-        init {
-            check(text.length <= 100) { "Content text length can only allow up to 100." }
-        }
+    public data class Header(public val text: CardElement.Text) : CardModule() {
+//        init {
+//            if (text is CardElement.PlainText) {
+//                check(text.content.length <= 100) { "Content text length can only allow up to 100." }
+//            }
+//        }
 
         public companion object {
             public const val TYPE: String = "header"

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/objects/CardMessageBuilder.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/objects/CardMessageBuilder.kt
@@ -183,7 +183,7 @@ public class CardModulesBuilder @JvmOverloads constructor(private val collect: M
      * 增加一个 [CardModule.Header]。
      */
     public fun header(text: String): CardModulesBuilder {
-        return add(CardModule.Header(text))
+        return add(CardModule.Header(CardElement.PlainText(text)))
     }
     //endregion
 


### PR DESCRIPTION
在收到卡片消息事件时，会出现 `Card` 反序列化异常的情况，导致无法获取 `event.messageContent.plainText` 或 `event.messageContent.messages`