### PR TITLE
修复 `MessageBtnClickEvent` 无法被正确触发的问题；增加组件模块下对 `MessageBtnClickEvent` 的支持事件类型 `KookMessageBtnClickEvent`

### DIFF
--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/system/user/MessageBtnClickEvent.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/system/user/MessageBtnClickEvent.kt
@@ -27,7 +27,7 @@ import love.forte.simbot.kook.objects.UserImpl
 
 /**
  *
- * [Card消息中的Button点击事件](https://developer.kaiheila.cn/doc/event/user#Card%E6%B6%88%E6%81%AF%E4%B8%AD%E7%9A%84Button%E7%82%B9%E5%87%BB%E4%BA%8B%E4%BB%B6)
+ * [Card消息中的Button点击事件](https://developer.kookapp.cn/doc/event/user#Card%20%E6%B6%88%E6%81%AF%E4%B8%AD%E7%9A%84%20Button%20%E7%82%B9%E5%87%BB%E4%BA%8B%E4%BB%B6)
  *
  *
  * type: [UserEvents.MESSAGE_BTN_CLICK]

--- a/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/system/user/UserEvents.kt
+++ b/simbot-component-kook-api/src/main/kotlin/love/forte/simbot/kook/event/system/user/UserEvents.kt
@@ -103,7 +103,7 @@ public object UserEvents {
      * @see MessageBtnClickEventBody
      */
     public val messageBtnClickEventParser: SysEventParser<MessageBtnClickEventBody> =
-        sysParser(SELF_JOINED_GUILD, MessageBtnClickEventBodyImpl.serializer())
+        sysParser(MESSAGE_BTN_CLICK, MessageBtnClickEventBodyImpl.serializer())
 
 }
 

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageBtnClickEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageBtnClickEvent.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.event
+
+import love.forte.simbot.ID
+import love.forte.simbot.Timestamp
+import love.forte.simbot.event.BaseEventKey
+import love.forte.simbot.event.Event
+import love.forte.simbot.kook.event.system.user.MessageBtnClickEventBody
+import love.forte.simbot.message.doSafeCast
+
+
+/**
+ * 一个 `Card` 中的按钮被按下的事件。
+ *
+ * @see MessageBtnClickEventBody
+ *
+ * @author ForteScarlet
+ */
+public abstract class KookMessageBtnClickEvent : KookSystemEvent<MessageBtnClickEventBody>() {
+    override val timestamp: Timestamp
+        get() = sourceEvent.msgTimestamp
+
+    /**
+     * 按钮 `return-val` 时的返回值
+     *
+     * @see MessageBtnClickEventBody.value
+     */
+    public val value: String get() = sourceBody.value
+
+
+    /**
+     * 点击的用户ID
+     *
+     * @see MessageBtnClickEventBody.userId
+     */
+    public val userId: ID get() = sourceBody.userId
+
+
+    override val key: Event.Key<out KookMessageBtnClickEvent>
+        get() = Key
+
+    public companion object Key : BaseEventKey<KookMessageBtnClickEvent>("kook.message_btn_click", KookSystemEvent) {
+        override fun safeCast(value: Any): KookMessageBtnClickEvent? = doSafeCast(value)
+    }
+}
+
+
+

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/BotStandardEventRegistrar.kt
@@ -49,10 +49,10 @@ internal suspend fun Event<*>.register(bot: KookComponentBotImpl) {
     when (this) {
         // 消息事件
         is MessageEvent<*> -> registerMessageEvent(bot)
-        
+
         // 系统事件
         is SystemEvent<*, Event.Extra.Sys<*>> -> registerSystemEvent(bot)
-        
+
         else -> {
             // 目前不太可能会触发此处
             pushUnsupported(bot)
@@ -84,7 +84,7 @@ private suspend fun MessageEvent<*>.registerMessageEvent(bot: KookComponentBotIm
                 }
             }
         }
-        
+
         Channel.Type.GROUP -> {
             val guild = bot.internalGuild(extra.guildId) ?: return
             val author = guild.getInternalMember(authorId) ?: return
@@ -121,25 +121,41 @@ private suspend fun MessageEvent<*>.registerMessageEvent(bot: KookComponentBotIm
 @Suppress("UnnecessaryOptInAnnotation")
 @OptIn(ExperimentalSimbotApi::class)
 private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotImpl) {
-    
     // 准备资源
-    val guild = bot.internalGuild(targetId) ?: return
-    
-    val author =
-        guild.getInternalMember(authorId)
-            ?: toMemberIfSystem(authorId, bot, guild)
-            ?: return
-    
+
+    // target_id
+    // 发送目的,
+    // 频道消息类时, 代表的是频道 channel_id，
+    // 如果 channel_type 为 GROUP 组播且 type 为 255 系统消息时，则代表服务器 guild_id
+
+    val guild: KookGuildImpl? = if (channelType == Channel.Type.GROUP) {
+        bot.internalGuild(targetId)
+    } else {
+        null
+    }
+
+//    val guild = bot.internalGuild(targetId) ?: return
+
+    // author_id
+    // 发送者 id, 1 代表系统
+
+    val author = guild?.let { g ->
+        g.getInternalMember(authorId)
+            ?: toMemberIfSystem(authorId, bot, g)
+//            ?: return // TODO ?
+    }
+
     @Suppress("UNCHECKED_CAST")
     when (val body = extra.body) {
         // region 成员变更相关
         // 某人退出事件
         is UserExitedChannelEventBody -> {
             // remove this user.
+            guild ?: return
             val removedMember = guild.internalMembers.remove(body.userId.literal)
                 ?.also { it.cancel() }
                 ?: return
-            
+
             bot.pushIfProcessable(KookMemberExitedChannelEvent) {
                 val channel = guild.getInternalChannel(body.channelId) ?: return
                 KookMemberExitedChannelEventImpl(
@@ -150,60 +166,61 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 )
             }
         }
-        
+
         is UserJoinedChannelEventBody -> bot.pushIfProcessable(KookMemberJoinedChannelEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.channelId) ?: return
             KookMemberJoinedChannelEventImpl(
                 bot,
                 this as Event<Event.Extra.Sys<UserJoinedChannelEventBody>>,
                 channel,
-                author
+                author ?: return
             )
         }
-        
+
         is ExitedGuildEventBody -> {
-            
+
             bot.pushIfProcessable(KookMemberExitedGuildEvent) {
                 KookMemberExitedGuildEventImpl(
                     bot,
                     this as Event<Event.Extra.Sys<ExitedGuildEventBody>>,
-                    guild,
-                    author
+                    guild ?: return,
+                    author ?: return
                 )
             }
         }
-        
+
         is JoinedGuildEventBody -> bot.pushIfProcessable(KookMemberJoinedGuildEvent) {
             KookMemberJoinedGuildEventImpl(
                 bot,
                 this as Event<Event.Extra.Sys<JoinedGuildEventBody>>,
-                guild,
-                author
+                guild ?: return,
+                author ?: return
             )
         }
-        
+
         is SelfExitedGuildEventBody -> bot.pushIfProcessable(KookBotSelfExitedGuildEvent) {
             KookBotSelfExitedGuildEventImpl(
                 bot,
                 this as Event<Event.Extra.Sys<SelfExitedGuildEventBody>>,
-                guild,
-                author
+                guild ?: return,
+                author ?: return
             )
         }
-        
+
         is SelfJoinedGuildEventBody -> bot.pushIfProcessable(KookBotSelfJoinedGuildEvent) {
             KookBotSelfJoinedGuildEventImpl(
                 bot,
                 this as Event<Event.Extra.Sys<SelfJoinedGuildEventBody>>,
-                guild,
-                author
+                guild ?: return,
+                author ?: return
             )
         }
-        
+
         // online
         is GuildMemberOnlineEventBody -> {
             val userInfo = bot.findUserInGuilds(body.userId, body.guilds) ?: return
-            
+
             bot.pushIfProcessable(KookUserOnlineStatusChangedEvent.Online) {
                 KookMemberOnlineEventImpl(
                     bot,
@@ -212,11 +229,11 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 )
             }
         }
-        
+
         // offline
         is GuildMemberOfflineEventBody -> {
             val userInfo = bot.findUserInGuilds(body.userId, body.guilds) ?: return
-            
+
             bot.pushIfProcessable(KookUserOnlineStatusChangedEvent.Offline) {
                 KookMemberOfflineEventImpl(
                     bot,
@@ -225,9 +242,9 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 )
             }
         }
-        
+
         // endregion
-        
+
         // region 用户信息更新事件
         is UserUpdatedEventBody -> bot.pushIfProcessable(KookUserUpdatedEvent) {
             KookUserUpdatedEventImpl(
@@ -236,9 +253,10 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
             )
         }
         // endregion
-        
+
         // region 频道变更事件
         is AddedChannelExtraBody -> bot.pushIfProcessable(KookAddedChannelChangedEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.id) ?: return
             KookAddedChannelChangedEventImpl(
                 bot,
@@ -246,8 +264,9 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 guild, channel
             )
         }
-        
+
         is UpdatedChannelExtraBody -> bot.pushIfProcessable(KookUpdatedChannelChangedEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.id) ?: return
             KookUpdatedChannelChangedEventImpl(
                 bot,
@@ -255,8 +274,9 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 guild, channel
             )
         }
-        
+
         is DeletedChannelExtraBody -> bot.pushIfProcessable(KookDeletedChannelChangedEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.id) ?: return
             KookDeletedChannelChangedEventImpl(
                 bot,
@@ -264,8 +284,9 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 guild, channel
             )
         }
-        
+
         is PinnedMessageExtraBody -> bot.pushIfProcessable(KookPinnedMessageEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.channelId) ?: return
             val operator = guild.getInternalMember(body.operatorId)
             KookPinnedMessageEventImpl(
@@ -274,8 +295,9 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 guild, channel, operator
             )
         }
-        
+
         is UnpinnedMessageExtraBody -> bot.pushIfProcessable(KookUnpinnedMessageEvent) {
+            guild ?: return
             val channel = guild.getInternalChannel(body.channelId) ?: return
             val operator = guild.getInternalMember(body.operatorId)
             KookUnpinnedMessageEventImpl(
@@ -284,18 +306,25 @@ private suspend fun SystemEvent<*, *>.registerSystemEvent(bot: KookComponentBotI
                 guild, channel, operator
             )
         }
-        
+
         // endregion
-        
-        
+
+        // btn
+        is MessageBtnClickEventBody -> bot.pushIfProcessable(KookMessageBtnClickEvent) {
+            KookMessageBtnClickEventImpl(
+                bot,
+                this as Event<Event.Extra.Sys<MessageBtnClickEventBody>>
+            )
+        }
+
         // other..?
-        
-        
+
+
         // 其他未知事件类型
         else -> pushUnsupported(bot)
     }
-    
-    
+
+
 }
 
 private suspend fun KookComponentBotImpl.findUserInGuilds(userId: ID, guildIds: Collection<ID>): UserInfo? {
@@ -322,7 +351,7 @@ private suspend inline fun KookComponentBotImpl.pushIfProcessable(
         }
         return true
     }
-    
+
     return false
 }
 
@@ -335,6 +364,6 @@ private fun toMemberIfSystem(
     if (id != SystemUser.id) {
         return null
     }
-    
+
     return KookGuildMemberImpl(bot, guild, SystemUser.toModel())
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageBtnClickEventImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageBtnClickEventImpl.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.internal.event
+
+import love.forte.simbot.component.kook.event.KookMessageBtnClickEvent
+import love.forte.simbot.component.kook.internal.KookComponentBotImpl
+import love.forte.simbot.kook.event.Event
+import love.forte.simbot.kook.event.system.user.MessageBtnClickEventBody
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+internal class KookMessageBtnClickEventImpl(
+    override val bot: KookComponentBotImpl,
+    override val sourceEvent: Event<Event.Extra.Sys<MessageBtnClickEventBody>>,
+) : KookMessageBtnClickEvent()

--- a/simbot-component-kook-core/src/test/resources/simbot-logger-slf4j.properties
+++ b/simbot-component-kook-core/src/test/resources/simbot-logger-slf4j.properties
@@ -1,0 +1,1 @@
+level.love.forte.simbot.kook.bot.event=TRACE


### PR DESCRIPTION
```kotlin
@Listener
suspend fun onBtnClick(event: KookMessageBtnClickEvent) {
    // ...
}
```

close https://github.com/simple-robot/simpler-robot/issues/708
