### PR TITLE
核心模块提供 `KookTempTarget` 支持追加临时消息id

### DIFF
--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/KookChannelImpl.kt
@@ -84,20 +84,11 @@ internal class KookChannelImpl private constructor(
     override suspend fun member(id: ID): KookGuildMember? = _guild.member(id)
     
     override suspend fun send(message: Message, quote: ID?, tempTargetId: ID?): KookMessageReceipt {
-        return message.sendToChannel(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId)
-            ?: throw SimbotIllegalArgumentException("Valid messages must not be empty.")
-        // val request = message.toRequest(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId)
-        //     ?: throw SimbotIllegalArgumentException("Valid messages must not be empty.")
-        //
-        // val result = request.requestDataBy(baseBot)
-        //
-        // return if (result is MessageCreated) {
-        //     result.asReceipt(false, baseBot)
-        // } else {
-        //     KookApiRequestedReceipt(result, false, baseBot)
-        // }
+        return send0(message, quote, tempTargetId, null)
+//        return message.sendToChannel(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId)
+//            ?: throw SimbotIllegalArgumentException("Valid messages must not be empty.")
     }
-    
+
     override suspend fun send(message: MessageContent, quote: ID?, tempTargetId: ID?): KookMessageReceipt {
         return when (message) {
             is KookReceiveMessageContent -> {
@@ -128,6 +119,12 @@ internal class KookChannelImpl private constructor(
                 send(message.messages)
             }
         }
+    }
+
+
+    internal suspend fun send0(message: Message, quote: ID?, tempTargetId: ID?, defaultTempTargetId: ID?): KookMessageReceipt {
+        return message.sendToChannel(bot, targetId = source.id, quote = quote, tempTargetId = tempTargetId, defaultTempTargetId = defaultTempTargetId)
+            ?: throw SimbotIllegalArgumentException("Valid messages must not be empty.")
     }
     
     override fun toString(): String {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageEventImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/internal/event/KookMessageEventImpl.kt
@@ -58,7 +58,7 @@ internal class KookChannelMessageEventImpl(
     override suspend fun channel(): KookChannel = _channel
     
     override suspend fun reply(message: Message): KookMessageReceipt {
-        return _channel.send(message, sourceEvent.msgId)
+        return _channel.send0(message, sourceEvent.msgId, null, _author.id)
     }
     
     override suspend fun reply(text: String): KookMessageReceipt {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessages.kt
@@ -17,7 +17,9 @@
 
 package love.forte.simbot.component.kook.message
 
-import love.forte.simbot.*
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.ID
+import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.component.kook.KookComponentBot
 import love.forte.simbot.component.kook.util.requestDataBy
 import love.forte.simbot.kook.api.KookApiRequest
@@ -28,6 +30,7 @@ import love.forte.simbot.kook.api.message.MessageType
 import love.forte.simbot.kook.objects.AtTarget
 import love.forte.simbot.kook.objects.KMarkdown
 import love.forte.simbot.kook.objects.buildRawKMarkdown
+import love.forte.simbot.literal
 import love.forte.simbot.message.*
 import love.forte.simbot.resources.Resource.Companion.toResource
 import java.net.URL
@@ -84,6 +87,7 @@ public object KookMessages {
  *
  * 如果当前 [Message] 是一个消息链，则可能会根据消息类型的情况将消息转化为 `KMarkdown` 类型的消息。
  *
+ * @see Message.sendToChannel
  */
 @Deprecated(
     "Use Message.sendToChannel", ReplaceWith(

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookMessagesTransformer.kt
@@ -17,7 +17,9 @@
 
 package love.forte.simbot.component.kook.message
 
-import love.forte.simbot.*
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.ID
+import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.component.kook.KookComponentBot
 import love.forte.simbot.component.kook.message.KookAggregatedMessageReceipt.Companion.merge
 import love.forte.simbot.component.kook.message.KookMessageCreatedReceipt.Companion.asReceipt
@@ -30,6 +32,7 @@ import love.forte.simbot.kook.api.message.MessageCreated
 import love.forte.simbot.kook.api.message.MessageType
 import love.forte.simbot.kook.objects.AtTarget
 import love.forte.simbot.kook.objects.KMarkdownBuilder
+import love.forte.simbot.literal
 import love.forte.simbot.message.*
 import love.forte.simbot.resources.Resource.Companion.toResource
 import love.forte.simbot.utils.view.isNotEmpty
@@ -133,7 +136,17 @@ private suspend fun Message.send0(
     nonce: String? = null,
     tempTargetId: ID? = null,
 ): KookMessageReceipt? {
+    data class ReqData(
+        val type: Int,
+        val targetId: ID,
+        val content: String,
+        var nonce: String?,
+        var quote: ID?,
+        var tempTargetId: ID?,
+    )
+
     var quote0 = quote
+
     fun doRequest(type: Int, content: String): KookApiRequest<*> {
         return when (directType) {
             NOT_DIRECT -> MessageCreateRequest.create(
@@ -142,9 +155,9 @@ private suspend fun Message.send0(
                 content = content,
                 quote = quote0,
                 nonce = nonce,
-                tempTargetId = tempTargetId,
+                tempTargetId = null, // TODO
             )
-            
+
             DIRECT_TYPE_BY_TARGET -> DirectMessageCreateRequest.byTargetId(targetId, content, type, quote0, nonce)
             DIRECT_TYPE_BY_CODE -> DirectMessageCreateRequest.byChatCode(targetId, content, type, quote0, nonce)
             else -> throw SimbotIllegalArgumentException("Unknown direct type: $directType")
@@ -152,11 +165,11 @@ private suspend fun Message.send0(
             quote0 = null
         }
     }
-    
+
     val message = this
-    
+
     var kMarkdownBuilder: KMarkdownBuilder? = null
-    
+
     val requests: List<KookApiRequest<*>> = buildList(if (this is Message.Element<*>) 1 else (this as Messages).size) {
         // 清算 kmd
         fun liquidationKmd() {
@@ -165,14 +178,14 @@ private suspend fun Message.send0(
                 kMarkdownBuilder = null
             }
         }
-        
+
         suspend fun process(isSingle: Boolean, message: Message.Element<*>) {
             when (message) {
                 is KookRequestMessage -> {
                     liquidationKmd()
                     add(message.request)
                 }
-                
+
                 else -> {
                     message.elementToRequest(bot, isSingle, { type, content ->
                         liquidationKmd()
@@ -183,10 +196,10 @@ private suspend fun Message.send0(
                 }
             }
         }
-        
+
         when (message) {
             is Message.Element<*> -> process(true, message)
-            
+
             is Messages -> {
                 if (message.isNotEmpty()) {
                     val isSingle = message.size == 1
@@ -196,11 +209,11 @@ private suspend fun Message.send0(
                 }
             }
         }
-        
+
         liquidationKmd()
     }
-    
-    
+
+
     /*
         return if (result is MessageCreated) {
                 result.asReceipt(false, baseBot)
@@ -208,7 +221,7 @@ private suspend fun Message.send0(
                 KookApiRequestedReceipt(result, false, baseBot)
             }
      */
-    
+
     fun Any?.toReceipt(): SingleKookMessageReceipt {
         return if (this is MessageCreated) {
             this.asReceipt(false, bot)
@@ -216,16 +229,16 @@ private suspend fun Message.send0(
             KookApiRequestedReceipt(this, false, bot)
         }
     }
-    
+
     when {
         requests.isEmpty() -> {
             return null
         }
-        
+
         requests.size == 1 -> {
             return requests.first().requestDataBy(bot).toReceipt()
         }
-        
+
         else -> {
             return requests.map { req -> req.requestDataBy(bot).toReceipt() }.merge(bot = bot)
         }
@@ -244,19 +257,19 @@ private suspend fun Message.send0(
 @OptIn(ExperimentalSimbotApi::class)
 private suspend inline fun Message.Element<*>.elementToRequest(
     bot: KookComponentBot,
-    
+
     /**
      * 实际上的消息元素数量。如果需要发送的消息只有一个，那么处理时可能会选择直接使用 doRequest 而不是拼接内容到 kmd 中。
      *
      * 至少为1。
      */
     isSingleElement: Boolean,
-    
+
     /**
      * 得到（进行）一次请求
      */
     doRequest: (type: Int, content: String) -> Unit,
-    
+
     /**
      * 将信息填充到 kmd 中。kmd的发送是自动的，其产生于：
      * 执行中途的 doRequest 之前和全部元素遍历之后。
@@ -277,7 +290,7 @@ private suspend inline fun Message.Element<*>.elementToRequest(
                 }
             }
         }
-        
+
         is KookMessageElement<*> -> when (message) {
             // 媒体资源
             is KookAssetMessage<*> -> doRequest(message.type, message.asset.url)
@@ -285,54 +298,55 @@ private suspend inline fun Message.Element<*>.elementToRequest(
             is KookKMarkdownMessage -> doRequest(MessageType.KMARKDOWN.type, message.kMarkdown.rawContent)
             // card message
             is KookCardMessage -> doRequest(MessageType.CARD.type, message.cards.encode())
-            
+
             // is KookRequestMessage -> {
             //     this.request
             // }
-            
+
             is KookAtAllHere -> {
                 withinKmd {
                     at(AtTarget.Here)
                 }
             }
-            
+
             is KookAttachmentMessage -> {
                 val type: MessageType = when (message) {
-                    is SimpleKookAttachmentMessage -> when(val attType = message.attachment.type.lowercase()) {
+                    is SimpleKookAttachmentMessage -> when (val attType = message.attachment.type.lowercase()) {
                         "file" -> MessageType.FILE
                         "image" -> MessageType.IMAGE
                         "video" -> MessageType.VIDEO
                         else -> throw IllegalArgumentException("Unknown attachment type: $attType")
                     }
-        
+
                     is KookAttachmentFile -> MessageType.FILE
                     is KookAttachmentImage -> MessageType.IMAGE
                     is KookAttachmentVideo -> MessageType.VIDEO
                 }
-                
+
                 // TODO just re-upload and send, waiting for fix.
                 //  see https://github.com/simple-robot/simbot-component-kook/issues/75
-                
-                val createRequest = AssetCreateRequest.create(URL(message.attachment.url).toResource(message.attachment.name))
+
+                val createRequest =
+                    AssetCreateRequest.create(URL(message.attachment.url).toResource(message.attachment.name))
                 val asset = createRequest.requestDataBy(bot)
-                
+
                 doRequest(type.type, asset.url)
             }
-            
+
             else -> {
                 // other, ignore.
             }
         }
-        
+
         // 需要上传的图片
         is ResourceImage -> {
             val asset = AssetCreateRequest.create(message.resource()).requestDataBy(bot)
             doRequest(MessageType.IMAGE.type, asset.url)
         }
-        
+
         // 其他任意图片类型, 直接使用id
         is Image<*> -> doRequest(MessageType.IMAGE.type, message.id.literal)
-        
+
         // std at
         is At -> {
             withinKmd {
@@ -344,20 +358,20 @@ private suspend inline fun Message.Element<*>.elementToRequest(
                 }
             }
         }
-        
+
         is Face -> {
             // TODO guild emoji..?
             //  serverEmoticons?
         }
-        
+
         is Emoji -> {
             withinKmd {
                 emoji(message.id.literal)
-                
+
             }
         }
-        
-        
+
+
         else -> {
             // other..?
         }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookTempTarget.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookTempTarget.kt
@@ -17,22 +17,74 @@
 
 package love.forte.simbot.component.kook.message
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.ID
+import love.forte.simbot.component.kook.event.KookChannelMessageEvent
+import love.forte.simbot.component.kook.message.KookTempTarget.Key.byId
+import love.forte.simbot.component.kook.message.KookTempTarget.Key.current
+import love.forte.simbot.kook.api.message.MessageCreateRequest
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.doSafeCast
 
-// TODO
-
 /**
+ *
+ * 频道聊天消息中的**临时消息ID**。
+ *
+ * > `temp_target_id`: 用户 id,如果传了，代表该消息是临时消息，该消息不会存数据库，但是会在频道内只给该用户推送临时消息。用于在频道内针对用户的操作进行单独的回应通知等。
+ *
+ * 当消息链中存在时，会在最终产生的消息发送API中为 [MessageCreateRequest.tempTargetId] 填充用作临时消息ID的用户ID。
+ *
+ * 一个消息链中只会有**一个** [KookTempTarget] 最终生效，非频道消息无效。
+ *
+ * _更多说明参考 [KOOK文档](https://developer.kookapp.cn/doc/http/message#%E5%8F%91%E9%80%81%E9%A2%91%E9%81%93%E8%81%8A%E5%A4%A9%E6%B6%88%E6%81%AF)_
+ *
+ * @see MessageCreateRequest
+ * @see byId
+ * @see current
  *
  * @author ForteScarlet
  */
 @Serializable
-public data class KookTempTarget(val id: ID) : KookMessageElement<KookTempTarget> {
+@SerialName("kook.temp.target")
+public sealed class KookTempTarget : KookMessageElement<KookTempTarget> {
     override val key: Message.Key<KookTempTarget> get() = Key
 
     public companion object Key : Message.Key<KookTempTarget> {
         override fun safeCast(value: Any): KookTempTarget? = doSafeCast(value)
+
+        /**
+         * 指定一个具体的ID目标作为临时消息的目标用户ID。
+         */
+        @JvmStatic
+        public fun byId(id: ID): KookTempTarget = Target(id)
+
+        /**
+         * 使用“当前”事件中的用户ID。
+         *
+         * 当通过 [KookChannelMessageEvent.reply] 时，通过 [current] 可以自动填充当前事件中的用户目标ID。
+         * 其他情况下 [current] 将会被忽略。
+         *
+         * 如果希望指定具体的用户ID，参考 [byId]。
+         */
+        @JvmStatic
+        public fun current(): KookTempTarget = Current
+
     }
+
+
+    /**
+     * 指定具体的用户ID
+     */
+    internal data class Target(val id: ID) : KookTempTarget()
+
+
+    /**
+     * 尝试自动使用可获取到的目标用户ID
+     */
+    internal object Current : KookTempTarget() {
+        override fun equals(other: Any?): Boolean = this === other
+        override fun toString(): String = "Current"
+    }
+
 }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookTempTarget.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/message/KookTempTarget.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.message
+
+import kotlinx.serialization.Serializable
+import love.forte.simbot.ID
+import love.forte.simbot.message.Message
+import love.forte.simbot.message.doSafeCast
+
+// TODO
+
+/**
+ *
+ * @author ForteScarlet
+ */
+@Serializable
+public data class KookTempTarget(val id: ID) : KookMessageElement<KookTempTarget> {
+    override val key: Message.Key<KookTempTarget> get() = Key
+
+    public companion object Key : Message.Key<KookTempTarget> {
+        override fun safeCast(value: Any): KookTempTarget? = doSafeCast(value)
+    }
+}

--- a/simbot-component-kook-core/src/test/resources/simbot-logger-slf4j.properties
+++ b/simbot-component-kook-core/src/test/resources/simbot-logger-slf4j.properties
@@ -1,1 +1,2 @@
 level.love.forte.simbot.kook.bot.event=TRACE
+level.love.forte.simbot.kook.api=DEBUG


### PR DESCRIPTION
```kotlin
val event: KookChannelMessageEvent = ...

event.reply(Text { "hello" } + KookTempTarget.current() ) // 自动填充当前事件内的 author id

event.chennal().send(Text { "hi!" } + KookTempTarget.byId(event.author().id)) // 其他情况下指定具体ID
```

close https://github.com/simple-robot/simpler-robot/issues/718