### PR TITLE
增加 `extra` 的特殊实现类型 `UnknownExtra`

### DIFF
--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/Event.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/Event.kt
@@ -20,10 +20,12 @@ package love.forte.simbot.kook.event
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.InternalSimbotApi
 import love.forte.simbot.kook.objects.SimpleAttachments
 import love.forte.simbot.kook.objects.SimpleUser
 import love.forte.simbot.kook.objects.kmd.RawValueKMarkdown
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 
 /**
@@ -509,4 +511,46 @@ public sealed class SystemExtra : EventExtra() {
      */
     @Contextual
     public abstract val body: Any?
+}
+
+
+/**
+ * 当一个事件反序列化失败的时候，会被**尝试**使用 [UnknownExtra] 作为 `extra` 的序列化目标。
+ * 如果是因为一个未知的事件导致的这次失败，则 [UnknownExtra] 便会反序列化成功并被推送。
+ *
+ */
+@Serializable
+@SerialName("$\$UNKNOWN")
+public class UnknownExtra : EventExtra() {
+    @Transient
+    private lateinit var _source: String
+
+    /**
+     * 接收到的完整的原始事件JSON字符串
+     */
+    public val source: String
+        get() = _source
+
+    /**
+     * @suppress 内部使用，用于初始化 [source] 值
+     */
+    @InternalSimbotApi
+    @JvmSynthetic
+    public fun initSource(source: String) {
+        if (sourceInitialized) {
+            throw IllegalStateException("'source' has already initialized")
+        }
+
+        _source = source
+    }
+
+    private val sourceInitialized get() = ::_source.isInitialized
+
+    override fun toString(): String {
+        if (!sourceInitialized) {
+            return "UnknownExtra(source=<UNINITIALIZED>)"
+        }
+
+        return "UnknownExtra(source=$source)"
+    }
 }

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/Event.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/Event.kt
@@ -20,6 +20,7 @@ package love.forte.simbot.kook.event
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.InternalSimbotApi
 import love.forte.simbot.kook.objects.SimpleAttachments
 import love.forte.simbot.kook.objects.SimpleUser
@@ -197,9 +198,15 @@ public data class Event<out E : EventExtra>(
 /**
  * 事件的消息 `extra`。
  *
+ * ### [UnknownExtra]
+ *
+ * [UnknownExtra] 与其他子类型有所不同。[UnknownExtra] 是由框架定义并实现的特殊类型，
+ * 它用来承载那些接收后无法被解析或尚未支持的事件类型。
+ *
  * @see Event.extra
  * @see TextExtra
  * @see SystemExtra
+ * @see UnknownExtra
  *
  */
 @Serializable
@@ -518,7 +525,18 @@ public sealed class SystemExtra : EventExtra() {
  * 当一个事件反序列化失败的时候，会被**尝试**使用 [UnknownExtra] 作为 `extra` 的序列化目标。
  * 如果是因为一个未知的事件导致的这次失败，则 [UnknownExtra] 便会反序列化成功并被推送。
  *
+ *  [UnknownExtra] 不会提供任何可反序列化的属性，
+ *  取而代之的是提供了 [source] 来获取本次反序列化失败的的原始JSON字符串信息。
+ *  你可以通过 [source] 来做一些临时性处理，例如解析并获取其中的信息。
+ *
+ *
+ *  ### FragileSimbotApi
+ *
+ *  [UnknownExtra] 类型的事件会随着支持的事件类型的增多而减少。
+ *  对可能造成 [UnknownExtra] 出现概率降低的更新不会做专门的提示。
+ *  因此使用 [UnknownExtra] 时应当明确了解其可能出现的内容，同时不可过分依赖它。
  */
+@FragileSimbotApi
 @Serializable
 @SerialName("$\$UNKNOWN")
 public class UnknownExtra : EventExtra() {

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
@@ -20,6 +20,7 @@ package love.forte.simbot.component.kook.bot.internal
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import love.forte.simbot.DiscreetSimbotApi
+import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.component.kook.event.*
 import love.forte.simbot.component.kook.event.internal.*
 import love.forte.simbot.component.kook.internal.KookChannelCategoryImpl
@@ -39,6 +40,7 @@ import love.forte.simbot.kook.event.Event as KEvent
 import love.forte.simbot.kook.objects.User as KUser
 
 
+@OptIn(FragileSimbotApi::class)
 internal fun KookBotImpl.registerEvent() {
     val thisBot = this
     sourceBot.processor(ProcessorType.PREPARE) {
@@ -555,7 +557,6 @@ internal fun KookBotImpl.registerEvent() {
             }
 
             is UnknownExtra -> {
-                //  TODO 对应的事件
                 pushUnsupported(event)
             }
         }

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
@@ -553,6 +553,11 @@ internal fun KookBotImpl.registerEvent() {
 
 
             }
+
+            is UnknownExtra -> {
+                //  TODO 对应的事件
+                pushUnsupported(event)
+            }
         }
 
 

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageEvent.kt
@@ -318,3 +318,7 @@ public abstract class KookBotSelfMessageEvent : KookMessageEvent.Person() {
         override fun safeCast(value: Any): KookBotSelfMessageEvent? = doSafeCast(value)
     }
 }
+
+
+
+// TODO 消息更新、消息删除

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/UnsupportedKookEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/UnsupportedKookEvent.kt
@@ -26,6 +26,7 @@ import love.forte.simbot.delegate.stringID
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.kook.event.Event
 import love.forte.simbot.kook.event.EventExtra
+import love.forte.simbot.kook.event.UnknownExtra
 import love.forte.simbot.message.doSafeCast
 
 
@@ -42,6 +43,11 @@ import love.forte.simbot.message.doSafeCast
  *
  * 因此你应当首先查看 [KookEvent] 下是否有所需的已经实现的事件类型，并且不应当过分依赖 [UnsupportedKookEvent].
  *
+ * ### [UnknownExtra]
+ *
+ * [`sourceEvent.extra`][Event.extra] 中（理所应当地）有可能会出现 [UnknownExtra]。
+ * [UnknownExtra] 的含义与其他 [EventExtra] 的含义略有区别。详细说明可参考 [UnknownExtra] 的文档描述。
+ *
  * @author ForteScarlet
  */
 @DiscreetSimbotApi
@@ -49,6 +55,7 @@ public class UnsupportedKookEvent(
     override val bot: KookBot,
     override val sourceEvent: Event<EventExtra>,
 ) : KookEvent<EventExtra, Event<EventExtra>>() {
+
     /**
      * 事件ID。
      */

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/exceptions.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/exceptions.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.kook
 
 import io.ktor.websocket.*
+import kotlinx.serialization.SerializationException
 
 /**
  * bot启动过程中、连接失败（比如多次重试仍无法连接）时抛出的异常。
@@ -52,4 +53,14 @@ public class KookBotClientCloseException : KookException {
     }
 }
 
-
+/**
+ * 事件接收中因为事件无法反序列化而导致的错误。
+ *
+ */
+public class EventDeserializationException(
+    /**
+     * 接收到的原始消息字符串
+     */
+    public val source: String,
+    message: String, cause: SerializationException
+) : KookException(message, cause)

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/internal/BotImpl.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/internal/BotImpl.kt
@@ -57,6 +57,8 @@ internal class BotImpl(
     private val botLogger = LoggerFactory.getLogger("love.forte.simbot.kook.bot.${ticket.clientId}")
     internal val eventLogger = LoggerFactory.getLogger("love.forte.simbot.kook.event.${ticket.clientId}")
 
+    // TODO 异常处理器或未知事件处理
+
     override val authorization: String = "${ticket.type.prefix} ${ticket.token}"
 
     private val queueMap = ActualEnumMap.create<ProcessorType, EventProcessorQueue<EventProcessor>> {

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/internal/BotStates.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/internal/BotStates.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.*
+import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.InternalSimbotApi
 import love.forte.simbot.kook.KookBotClientCloseException
 import love.forte.simbot.kook.KookBotConnectException
@@ -532,14 +533,35 @@ private class Receiving(
                     event = try {
                         json.decodeFromJsonElement(deserializer, jsonElement)
                     } catch (se: SerializationException) {
-                        try {
+                        var throwIt = false
+
+                        @OptIn(FragileSimbotApi::class)
+                        val event0: Signal.Event<EventExtra>? = try {
                             json.decodeFromJsonElement(Signal.Event.serializer(UnknownExtra.serializer()), jsonElement).also {
                                 it.data.extra.initSource(eventString)
                             }
                         } catch (e1: Exception) {
                             se.addSuppressed(e1)
+                            throwIt = true
+                            null
+                        }
+
+                        if (event0 == null) {
+                            // try to get sn and update
+                            val sn = ((jsonElement as? JsonObject)?.get("sn") as? JsonPrimitive)?.longOrNull
+                            if (sn != null) {
+                                updateSn(sn)
+                            } else {
+                                val snEx = IllegalStateException("'sn' not found in event json, can not update sn for it")
+                                se.addSuppressed(snEx)
+                            }
+                        }
+
+                        if (throwIt) {
                             throw se
                         }
+
+                        event0!!
                     }
                 }
 
@@ -548,7 +570,7 @@ private class Receiving(
 
                 // 更新 sn, 保留最大值
                 val eventSn = event.sn.toLong()
-                val currentSn = client.sn.updateSn(eventSn)
+                val currentSn = updateSn(eventSn)
                 if (eventSn < currentSn) {
                     eventLogger.debug("Event sn {} < current sn {}, ignore and skip this event.", eventSn, currentSn)
                     return this
@@ -586,6 +608,8 @@ private class Receiving(
 
         return this
     }
+
+    private fun updateSn(eventSn: Long) = client.sn.updateSn(eventSn)
 
     private fun AtomicLongRef.updateSn(newSn: Long): Long {
         return updateAndGet { v -> max(newSn, v) }


### PR DESCRIPTION
顾名思义 `UnknownExtra` 用于解决接收到的那些无法解析或尚未支持的事件类型，并将它们统一包装为此特殊类型推送。

在core模块中 `UnknownExtra` 会出现在 `UnsupportedKookEvent` 中（而不是独立的事件类型）。

同时也处理了 [simbot#741](https://github.com/simple-robot/simpler-robot/issues/741) 中出现**"持续输出错误日志"**的问题。

resolve #109, https://github.com/simple-robot/simpler-robot/issues/741