### PR TITLE
api和core模块中增加对频道消息撤回，更新、私聊消息撤回，更新的支持

### DIFF
--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/ChannelEventExtras.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/ChannelEventExtras.kt
@@ -196,7 +196,7 @@ public data class UpdatedMessageEventExtra(override val body: Body) : SystemExtr
          * 提及的角色 id 组成的列表
          */
         @SerialName("mention_roles")
-        val mentionRoles: List<String> = emptyList(),
+        val mentionRoles: List<Int> = emptyList(),
 
         /**
          * 更新时间戳(毫秒)

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/PrivateMessageEventExtras.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/event/PrivateMessageEventExtras.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.kook.event
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * [私聊消息更新](https://developer.kookapp.cn/doc/event/direct-message#%E7%A7%81%E8%81%8A%E6%B6%88%E6%81%AF%E6%9B%B4%E6%96%B0)
+ *
+ * @author ForteScarlet
+ */
+@Serializable
+@SerialName(UpdatedPrivateMessageEventExtra.TYPE)
+public data class UpdatedPrivateMessageEventExtra(override val body: Body) : SystemExtra() {
+    public companion object {
+        public const val TYPE: String = "updated_private_message"
+    }
+
+    /**
+     * [UpdatedPrivateMessageEventExtra] 事件的事件体
+     * @see UpdatedPrivateMessageEventExtra.body
+     */
+    @Serializable
+    public data class Body(
+        /**
+         * 被更新的消息的 id
+         */
+        @SerialName("msg_id") val msgId: String,
+        /**
+         * 被更新的消息的创建者 id
+         */
+        @SerialName("author_id") val authorId: String,
+        /**
+         * 被更新的消息的目标用户 id
+         */
+        @SerialName("target_id") val targetId: String,
+        /**
+         * 更新后的文本
+         */
+        val content: String,
+        /**
+         * 私聊 code
+         */
+        @SerialName("chat_code") val chatCode: String,
+        /**
+         * 更新时间戳(毫秒)
+         */
+        @SerialName("updated_at") val updatedAt: Long,
+    )
+}
+
+/**
+ * [私聊消息删除](https://developer.kookapp.cn/doc/event/direct-message#%E7%A7%81%E8%81%8A%E6%B6%88%E6%81%AF%E8%A2%AB%E5%88%A0%E9%99%A4)
+ *
+ * @author ForteScarlet
+ */
+@Serializable
+@SerialName(DeletedPrivateMessageEventExtra.TYPE)
+public data class DeletedPrivateMessageEventExtra(override val body: Body) : SystemExtra() {
+    public companion object {
+        public const val TYPE: String = "deleted_private_message"
+    }
+
+    /**
+     * [DeletedPrivateMessageEventExtra] 事件的事件体
+     * @see DeletedPrivateMessageEventExtra.body
+     */
+    @Serializable
+    public data class Body(
+        /**
+         * 被删除的消息的 id
+         */
+        @SerialName("msg_id") val msgId: String,
+        /**
+         * 被删除的消息的创建者 id
+         */
+        @SerialName("author_id") val authorId: String,
+        /**
+         * 被删除的消息的目标用户 id
+         */
+        @SerialName("target_id") val targetId: String,
+        /**
+         * 私聊 code
+         */
+        @SerialName("chat_code") val chatCode: String,
+        /**
+         * 删除的时间戳(毫秒)
+         */
+        @SerialName("deleted_at") val deletedAt: Long,
+    )
+}
+
+
+// TODO 私聊内用户添加 reaction etc.
+// https://developer.kookapp.cn/doc/event/direct-message#%E7%A7%81%E8%81%8A%E5%86%85%E7%94%A8%E6%88%B7%E6%B7%BB%E5%8A%A0%20reaction

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
@@ -488,6 +488,13 @@ internal fun KookBotImpl.registerEvent() {
                         }
                     }
 
+                    // 频道消息删除
+                    is DeletedMessageEventExtra -> {
+                        pushIfProcessable(KookDeletedChannelMessageEvent) {
+                            KookDeletedChannelMessageEventImpl(thisBot, event.doAs())
+                        }
+                    }
+
                     // 按钮点击
                     is MessageBtnClickEventExtra -> {
                         pushIfProcessable(KookMessageBtnClickEvent) {
@@ -544,6 +551,16 @@ internal fun KookBotImpl.registerEvent() {
                     is UserUpdatedEventExtra -> {
                         pushIfProcessable(KookUserUpdatedEvent) {
                             KookUserUpdatedEventImpl(
+                                thisBot,
+                                event.doAs()
+                            )
+                        }
+                    }
+
+                    // 私聊消息删除
+                    is DeletedPrivateMessageEventExtra -> {
+                        pushIfProcessable(KookDeletedPrivateMessageEvent) {
+                            KookDeletedPrivateMessageEventImpl(
                                 thisBot,
                                 event.doAs()
                             )

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
@@ -43,7 +43,7 @@ import love.forte.simbot.kook.objects.User as KUser
 @OptIn(FragileSimbotApi::class)
 internal fun KookBotImpl.registerEvent() {
     val thisBot = this
-    sourceBot.processor(ProcessorType.PREPARE) {
+    sourceBot.processor(ProcessorType.PREPARE) { rawEvent ->
         val event = this
 
         when (val ex = extra) {
@@ -495,6 +495,13 @@ internal fun KookBotImpl.registerEvent() {
                         }
                     }
 
+                    // 频道消息更新
+                    is UpdatedMessageEventExtra -> {
+                        pushIfProcessable(KookUpdatedChannelMessageEvent) {
+                            KookUpdatedChannelMessageEventImpl(thisBot, event.doAs())
+                        }
+                    }
+
                     // 按钮点击
                     is MessageBtnClickEventExtra -> {
                         pushIfProcessable(KookMessageBtnClickEvent) {
@@ -561,6 +568,16 @@ internal fun KookBotImpl.registerEvent() {
                     is DeletedPrivateMessageEventExtra -> {
                         pushIfProcessable(KookDeletedPrivateMessageEvent) {
                             KookDeletedPrivateMessageEventImpl(
+                                thisBot,
+                                event.doAs()
+                            )
+                        }
+                    }
+
+                    // 私聊消息更新
+                    is UpdatedPrivateMessageEventExtra -> {
+                        pushIfProcessable(KookUpdatedPrivateMessageEvent) {
+                            KookUpdatedPrivateMessageEventImpl(
                                 thisBot,
                                 event.doAs()
                             )

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookDeletedMessageEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookDeletedMessageEvent.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.event
+
+import love.forte.simbot.ID
+import love.forte.simbot.Timestamp
+import love.forte.simbot.event.BaseEventKey
+import love.forte.simbot.kook.event.DeletedMessageEventExtra
+import love.forte.simbot.kook.event.DeletedPrivateMessageEventExtra
+import love.forte.simbot.kook.event.Event
+import love.forte.simbot.kook.event.SystemExtra
+import love.forte.simbot.message.doSafeCast
+
+
+/**
+ * KOOK 系统事件中与 _消息删除_ 相关的事件的simbot事件基准类。
+ *
+ * 涉及的 KOOK 原始事件 (的 [SystemExtra] 子类型) 有：
+ * - [DeletedMessageEventExtra]
+ * - [DeletedPrivateMessageEventExtra]
+ *
+ * @author ForteScarlet
+ *
+ * @see KookSystemEvent
+ */
+public abstract class KookDeletedMessageEvent : KookSystemEvent() {
+    /**
+     * 源事件
+     */
+    abstract override val sourceEvent: Event<SystemExtra>
+
+    /**
+     * 源事件中的事件体
+     */
+    abstract override val sourceBody: Any?
+
+    /**
+     * 被删除的消息的ID
+     */
+    public abstract val deletedMsgId: ID
+
+    /**
+     * 消息被删除的时间
+     */
+    abstract override val timestamp: Timestamp
+
+    abstract override val key: love.forte.simbot.event.Event.Key<out KookSystemEvent>
+
+    public companion object Key : BaseEventKey<KookDeletedMessageEvent>(
+        "kook.deleted_message_event", KookSystemEvent
+    ) {
+        override fun safeCast(value: Any): KookDeletedMessageEvent? = doSafeCast(value)
+    }
+}
+
+
+/**
+ * KOOK中一个频道消息被删除的事件。
+ *
+ * @see KookDeletedMessageEvent
+ *
+ */
+public abstract class KookDeletedChannelMessageEvent : KookDeletedMessageEvent() {
+    /**
+     * 频道消息被删除事件的源事件
+     */
+    abstract override val sourceEvent: Event<DeletedMessageEventExtra>
+
+    /**
+     * [sourceEvent] 的事件体。
+     *
+     * @see DeletedMessageEventExtra.Body
+     */
+    override val sourceBody: DeletedMessageEventExtra.Body
+        get() = sourceEvent.extra.body
+
+    /**
+     * 被删除的消息的ID
+     */
+    override val deletedMsgId: ID
+        get() = sourceBody.msgId.ID
+
+    /**
+     * 消息删除时间。来自 [Event.msgTimestamp]
+     */
+    override val timestamp: Timestamp
+        get() = Timestamp.byMillisecond(sourceEvent.msgTimestamp)
+
+
+    override val key: love.forte.simbot.event.Event.Key<KookDeletedChannelMessageEvent>
+        get() = Key
+
+    public companion object Key : BaseEventKey<KookDeletedChannelMessageEvent>(
+        "kook.deleted_channel_message_event", KookDeletedMessageEvent
+    ) {
+        override fun safeCast(value: Any): KookDeletedChannelMessageEvent? = doSafeCast(value)
+    }
+}
+
+/**
+ * KOOK中一个私聊消息被删除的事件。
+ *
+ * @see KookDeletedMessageEvent
+ *
+ */
+public abstract class KookDeletedPrivateMessageEvent : KookDeletedMessageEvent() {
+    /**
+     * 私聊消息被删除事件的源事件
+     */
+    abstract override val sourceEvent: Event<DeletedPrivateMessageEventExtra>
+
+    /**
+     * [sourceEvent] 的事件体。
+     *
+     * @see DeletedPrivateMessageEventExtra.Body
+     */
+    override val sourceBody: DeletedPrivateMessageEventExtra.Body
+        get() = sourceEvent.extra.body
+
+    /**
+     * 被删除的消息的ID
+     */
+    override val deletedMsgId: ID
+        get() = sourceBody.msgId.ID
+
+    /**
+     * 被删除消息的创建者ID
+     */
+    public val authorId: ID
+        get() = sourceBody.authorId.ID
+
+    /**
+     * 被删除的消息的目标用户ID
+     */
+    public val targetId: ID
+        get() = sourceBody.targetId.ID
+
+    /**
+     * 私聊 code
+     */
+    public val chatCode: String
+        get() = sourceBody.chatCode
+
+    /**
+     * 消息删除时间。来自 [DeletedPrivateMessageEventExtra.Body.deletedAt]
+     */
+    override val timestamp: Timestamp
+        get() = Timestamp.byMillisecond(sourceBody.deletedAt)
+
+
+    override val key: love.forte.simbot.event.Event.Key<KookDeletedPrivateMessageEvent>
+        get() = Key
+
+    public companion object Key : BaseEventKey<KookDeletedPrivateMessageEvent>(
+        "kook.deleted_private_message_event", KookDeletedMessageEvent
+    ) {
+        override fun safeCast(value: Any): KookDeletedPrivateMessageEvent? = doSafeCast(value)
+    }
+}
+
+

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookDeletedMessageEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookDeletedMessageEvent.kt
@@ -59,7 +59,7 @@ public abstract class KookDeletedMessageEvent : KookSystemEvent() {
      */
     abstract override val timestamp: Timestamp
 
-    abstract override val key: love.forte.simbot.event.Event.Key<out KookSystemEvent>
+    abstract override val key: love.forte.simbot.event.Event.Key<out KookDeletedMessageEvent>
 
     public companion object Key : BaseEventKey<KookDeletedMessageEvent>(
         "kook.deleted_message_event", KookSystemEvent

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookMessageEvent.kt
@@ -320,5 +320,4 @@ public abstract class KookBotSelfMessageEvent : KookMessageEvent.Person() {
 }
 
 
-
 // TODO 消息更新、消息删除

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookUpdatedMessageEvent.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/KookUpdatedMessageEvent.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.event
+
+import love.forte.simbot.ID
+import love.forte.simbot.Timestamp
+import love.forte.simbot.component.kook.message.KookMessageContent
+import love.forte.simbot.component.kook.message.KookUpdatedMessageContent
+import love.forte.simbot.event.BaseEventKey
+import love.forte.simbot.kook.event.*
+import love.forte.simbot.message.doSafeCast
+
+
+/**
+ * KOOK 系统事件中与 _消息更新_ 相关的事件的simbot事件基准类。
+ *
+ * 涉及的 KOOK 原始事件 (的 [SystemExtra] 子类型) 有：
+ * - [UpdatedMessageEventExtra]
+ * - [UpdatedPrivateMessageEventExtra]
+ *
+ * @author ForteScarlet
+ *
+ * @see KookSystemEvent
+ */
+public abstract class KookUpdatedMessageEvent : KookSystemEvent() {
+    /**
+     * 源事件
+     */
+    abstract override val sourceEvent: Event<SystemExtra>
+
+    /**
+     * 源事件中的事件体
+     */
+    abstract override val sourceBody: Any?
+
+    /**
+     * 被更新的消息的ID
+     */
+    public abstract val updatedMsgId: ID
+
+    /**
+     * 被更新后的消息的原始正文文本
+     */
+    public abstract val updatedContent: String
+
+    /**
+     * 由更新后的消息文本 [updatedContent] 解析得到的 [KookMessageContent]。
+     */
+    public abstract val updatedMessageContent: KookUpdatedMessageContent
+
+    /**
+     * 消息被更新的时间
+     */
+    abstract override val timestamp: Timestamp
+
+    abstract override val key: love.forte.simbot.event.Event.Key<out KookUpdatedMessageEvent>
+
+    public companion object Key : BaseEventKey<KookUpdatedMessageEvent>(
+        "kook.updated_message_event", KookSystemEvent
+    ) {
+        override fun safeCast(value: Any): KookUpdatedMessageEvent? = doSafeCast(value)
+    }
+}
+
+
+/**
+ * KOOK中一个频道消息被更新的事件。
+ *
+ * @see KookDeletedMessageEvent
+ *
+ */
+public abstract class KookUpdatedChannelMessageEvent : KookUpdatedMessageEvent() {
+    /**
+     * 频道消息被更新事件的源事件
+     */
+    abstract override val sourceEvent: Event<UpdatedMessageEventExtra>
+
+    /**
+     * [sourceEvent] 的事件体。
+     *
+     * @see UpdatedMessageEventExtra.Body
+     */
+    override val sourceBody: UpdatedMessageEventExtra.Body
+        get() = sourceEvent.extra.body
+
+    /**
+     * 被更新的消息的ID
+     */
+    override val updatedMsgId: ID
+        get() = sourceBody.msgId.ID
+
+    /**
+     * 消息更新时间。来自 [Event.msgTimestamp]
+     */
+    override val timestamp: Timestamp
+        get() = Timestamp.byMillisecond(sourceEvent.msgTimestamp)
+
+    override val updatedContent: String
+        get() = sourceBody.content
+
+    override val updatedMessageContent: KookUpdatedMessageContent by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        KookUpdatedMessageContent(
+            bot = bot,
+            isDirect = false,
+            rawContent = sourceBody.content,
+            msgId = sourceBody.msgId,
+            mention = sourceBody.mention,
+            mentionRoles = sourceBody.mentionRoles,
+            isMentionAll = sourceBody.isMentionAll,
+            isMentionHere = sourceBody.isMentionHere,
+        )
+    }
+
+    override val key: love.forte.simbot.event.Event.Key<KookUpdatedChannelMessageEvent>
+        get() = Key
+
+    public companion object Key : BaseEventKey<KookUpdatedChannelMessageEvent>(
+        "kook.updated_channel_message_event", KookUpdatedMessageEvent
+    ) {
+        override fun safeCast(value: Any): KookUpdatedChannelMessageEvent? = doSafeCast(value)
+    }
+}
+
+/**
+ * KOOK中一个私聊消息被更新的事件。
+ *
+ * @see KookDeletedMessageEvent
+ *
+ */
+public abstract class KookUpdatedPrivateMessageEvent : KookUpdatedMessageEvent() {
+    /**
+     * 私聊消息被更新事件的源事件
+     */
+    abstract override val sourceEvent: Event<UpdatedPrivateMessageEventExtra>
+
+    /**
+     * [sourceEvent] 的事件体。
+     *
+     * @see UpdatedPrivateMessageEventExtra.Body
+     */
+    override val sourceBody: UpdatedPrivateMessageEventExtra.Body
+        get() = sourceEvent.extra.body
+
+    /**
+     * 被更新的消息的ID
+     */
+    override val updatedMsgId: ID
+        get() = sourceBody.msgId.ID
+
+    /**
+     * 被更新消息的创建者ID
+     */
+    public val authorId: ID
+        get() = sourceBody.authorId.ID
+
+    /**
+     * 被更新的消息的目标用户ID
+     */
+    public val targetId: ID
+        get() = sourceBody.targetId.ID
+
+    /**
+     * 私聊 code
+     */
+    public val chatCode: String
+        get() = sourceBody.chatCode
+
+    /**
+     * 消息更新时间。来自 [DeletedPrivateMessageEventExtra.Body.deletedAt]
+     */
+    override val timestamp: Timestamp
+        get() = Timestamp.byMillisecond(sourceBody.updatedAt)
+
+    override val updatedContent: String
+        get() = sourceBody.content
+
+    override val updatedMessageContent: KookUpdatedMessageContent by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        KookUpdatedMessageContent(
+            bot = bot,
+            isDirect = true,
+            rawContent = sourceBody.content,
+            msgId = sourceBody.msgId,
+            mention = emptyList(),
+            mentionRoles = emptyList(),
+            isMentionAll = false,
+            isMentionHere = false,
+        )
+    }
+
+    override val key: love.forte.simbot.event.Event.Key<KookUpdatedPrivateMessageEvent>
+        get() = Key
+
+    public companion object Key : BaseEventKey<KookUpdatedPrivateMessageEvent>(
+        "kook.updated_private_message_event", KookUpdatedMessageEvent
+    ) {
+        override fun safeCast(value: Any): KookUpdatedPrivateMessageEvent? = doSafeCast(value)
+    }
+}
+
+

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/internal/KookDeletedMessageEventImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/internal/KookDeletedMessageEventImpl.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.event.internal
+
+import love.forte.simbot.component.kook.bot.internal.KookBotImpl
+import love.forte.simbot.component.kook.event.KookDeletedChannelMessageEvent
+import love.forte.simbot.component.kook.event.KookDeletedPrivateMessageEvent
+import love.forte.simbot.kook.event.DeletedMessageEventExtra
+import love.forte.simbot.kook.event.DeletedPrivateMessageEventExtra
+import love.forte.simbot.kook.event.Event
+
+
+internal class KookDeletedChannelMessageEventImpl(
+    override val bot: KookBotImpl,
+    override val sourceEvent: Event<DeletedMessageEventExtra>,
+) : KookDeletedChannelMessageEvent()
+
+internal class KookDeletedPrivateMessageEventImpl(
+    override val bot: KookBotImpl,
+    override val sourceEvent: Event<DeletedPrivateMessageEventExtra>
+) : KookDeletedPrivateMessageEvent()

--- a/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/internal/KookUpdatedMessageEventImpl.kt
+++ b/simbot-component-kook-core/src/main/kotlin/love/forte/simbot/component/kook/event/internal/KookUpdatedMessageEventImpl.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023. ForteScarlet.
+ *
+ * This file is part of simbot-component-kook.
+ *
+ * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.event.internal
+
+import love.forte.simbot.component.kook.bot.KookBot
+import love.forte.simbot.component.kook.event.KookUpdatedChannelMessageEvent
+import love.forte.simbot.component.kook.event.KookUpdatedPrivateMessageEvent
+import love.forte.simbot.kook.event.Event
+import love.forte.simbot.kook.event.UpdatedMessageEventExtra
+import love.forte.simbot.kook.event.UpdatedPrivateMessageEventExtra
+
+
+internal class KookUpdatedChannelMessageEventImpl(
+    override val bot: KookBot,
+    override val sourceEvent: Event<UpdatedMessageEventExtra>
+) : KookUpdatedChannelMessageEvent()
+
+internal class KookUpdatedPrivateMessageEventImpl(
+    override val bot: KookBot,
+    override val sourceEvent: Event<UpdatedPrivateMessageEventExtra>
+) : KookUpdatedPrivateMessageEvent()


### PR DESCRIPTION
api模块新增事件 extra 实现：
- `UpdatedPrivateMessageEventExtra`
- `DeletedPrivateMessageEventExtra`

core模块新增事件类型：

- `KookUpdatedMessageEvent`
  - `KookUpdatedChannelMessageEvent`
  - `KookUpdatedPrivateMessageEvent`
- `KookDeletedMessageEvent`
  - `KookDeletedChannelMessageEvent`
  - `KookDeletedPrivateMessageEvent`

link:
- https://github.com/simple-robot/simpler-robot/issues/741

