### PR TITLE
实验性地尝试修改/优化当bot新加入一个频道服务器时的事件处理逻辑与机制

### DIFF
--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/KookUserChat.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/KookUserChat.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2022-2023. ForteScarlet.
+ *     Copyright (c) 2022-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.component.kook
@@ -35,7 +38,7 @@ import kotlin.jvm.JvmSynthetic
 /**
  * KOOK 的 [user-chat 私聊会话](https://developer.kaiheila.cn/doc/http/user-chat)。
  *
- * KOOK 组件会将 [私聊会话][KookUserChat] 视为 [Stranger] 处理，同时实现 [Contact] 来提供可交流的联系人能力。
+ * KOOK 组件会将 [私聊会话][KookUserChat] 视为 [Contact] 处理，同时实现 [Contact] 来提供可交流的联系人能力。
  *
  * ## 可删除的
  * KOOK 中的聊天会话是可以通过 [DeleteUserChatApi] 进行删除的。因此 [KookUserChat] 实现了 [DeleteSupport] 来支持 [删除操作][delete]。

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotManagerConfiguration.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotManagerConfiguration.kt
@@ -1,23 +1,27 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.component.kook.bot
 
 import kotlinx.coroutines.Job
+import love.forte.simbot.kook.stdlib.BotConfiguration
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotVerifyInfoConfiguration.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotVerifyInfoConfiguration.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.component.kook.bot
@@ -27,7 +30,7 @@ import love.forte.simbot.kook.stdlib.BotConfiguration
 import love.forte.simbot.kook.stdlib.ProcessorType
 
 /**
- * `.bot` 配置文件读取的配置信息实体, 用于接收从 [BotVerifyInfo] 中的序列化信息。
+ * `.bot` 配置文件读取的配置信息实体, 用于接收序列化配置信息。
  *
  * 在 [KookBotVerifyInfoConfiguration] 中，[Ticket.clientId] 和 [Ticket.token] 为必选项，
  * 存在于当前配置属性的最外层。除了必选项以外还存在部分可选项存在于 [KookBotVerifyInfoConfiguration.Config] 类型中，

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/event/KookBotEvent.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/event/KookBotEvent.kt
@@ -32,9 +32,6 @@ import love.forte.simbot.kook.event.Event as KEvent
 /**
  * Kook 组件的事件类型基类。
  *
- * @param E Kook api模块中所定义的原始 Kook 事件对象 [KEvent].
- * @param EX Kook api模块中所定义的原始 Kook 事件对象的 [extra][EventExtra] 属性类型。
- *
  * @see UnsupportedKookEvent
  * @see KookBotEvent
  * @see KookSystemEvent

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/util/BotRequests.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/util/BotRequests.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 @file:JvmName("KookBotRequests")
 
@@ -20,7 +23,9 @@ package love.forte.simbot.component.kook.util
 
 import io.ktor.client.statement.*
 import love.forte.simbot.component.kook.bot.KookBot
-import love.forte.simbot.kook.api.*
+import love.forte.simbot.kook.api.ApiResult
+import love.forte.simbot.kook.api.KookApi
+import love.forte.simbot.kook.api.request
 import love.forte.simbot.kook.stdlib.requestBy
 import love.forte.simbot.kook.stdlib.requestDataBy
 import love.forte.simbot.kook.stdlib.requestResultBy
@@ -48,7 +53,7 @@ public suspend fun <T : Any> KookBot.requestData(api: KookApi<T>): T = api.reque
 /**
  * 使用 [KookBot] 对 [api] 发起请求。
  *
- * @see KookApi.requestRawBy
+ * @see KookApi.requestTextBy
  */
 @JvmSynthetic
 public suspend fun KookBot.requestText(api: KookApi<*>): String {
@@ -87,7 +92,7 @@ public suspend fun <T : Any> KookApi<T>.requestDataBy(bot: KookBot): T = bot.req
 /**
  * 使用 [KookApi] 通过 [bot] 发起请求。
  *
- * @see KookApi.requestRawBy
+ * @see KookApi.requestTextBy
  */
 @JvmSynthetic
 public suspend fun KookApi<*>.requestTextBy(bot: KookBot): String = bot.requestText(this)

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/internal/BotImpl.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/internal/BotImpl.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.kook.stdlib.internal
@@ -52,7 +55,7 @@ internal class BotImpl(
     private val botLogger = LoggerFactory.getLogger("love.forte.simbot.kook.bot.${ticket.clientId}")
     internal val eventLogger = LoggerFactory.getLogger("love.forte.simbot.kook.event.${ticket.clientId}")
 
-    // TODO 异常处理器或未知事件处理
+    // TODO 异常处理器?
 
     internal val authorization: String = "${ticket.type.prefix} ${ticket.token}"
 


### PR DESCRIPTION
此前的逻辑是这样的：
在收到'新加入频道服务器'的事件时，会获取它的详情、查询它的所有成员，用来初始化内部的缓存。这跟启动bot时初始化缓存的行为是类似的。

但是这里有个问题：这些行为是发生在 PREPARE 级别的处理器中的。也就是它会影响后续其他事件的处理。

比如新加入了一个 Guild A，然后在初始化它的过程中，后续其他任何事件都会等待它的完成才会继续处理。
这并不是很合理。因此新的逻辑被调整为：
在收到'新加入频道服务器'的事件时(假设这个频道服务器是 Guild A)，会创建一个异步的初始化任务。后续其他事件如果与这个 Guild A 相关(比如 Guild A 的消息事件)，则会在异步中等待它初始化完毕然后再进行处理。
此时，在Guild A初始化的这段时间内，与它有关的事件都会在异步中，不会影响到其他事件，而当它初始化完毕、能够在缓存中获取后，后续的其他任务便不会再进入异步了。

> [!caution]
> 此改动是实验性的，请仔细观察并积极上报任何与预期不符的行为，感谢您的贡献与支持！