### PR TITLE
废弃 `Bot.processor` 并重命名为 `Bot.subscribe`

### DIFF
--- a/Writerside/topics/use-stdlib.md
+++ b/Writerside/topics/use-stdlib.md
@@ -123,9 +123,9 @@ val bot = BotFactory.create(ticket) {
 }
 
 // 注册事件有一些不同但类似的方式
-// 1️⃣ 通过 processor 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件
-//     processor 是最基本的注册方式，也是其他方式的最终汇集点
-bot.processor { raw ->
+// 1️⃣ 通过 subscribe 注册一个普通的事件处理器，此处理器会接收并处理所有类型的事件
+//     subscribe 是最基本的注册方式，也是其他方式的最终汇集点
+bot.subscribe { raw ->
     // raw 代表事件的原始JSON字符串
     // this: Event<*>, 也就是解析出来的事件结构体
     println("event: $this")
@@ -133,11 +133,11 @@ bot.processor { raw ->
     println("raw: $raw")
 }
 
-// 2️⃣ 通过 processor<EventExtraType> 注册一个针对具体 Event<EventExtra> 事件类型的事件处理器，
+// 2️⃣ 通过 subscribe<EventExtraType> 注册一个针对具体 Event<EventExtra> 事件类型的事件处理器，
 //     它只有在接收到的 Event.extra 与目标类型一致时才会处理。
 //     此示例展示处理 KMarkdownEventExtra 也就 KMarkdown 类型的消息事件，
 //     并在对方发送了包含 'stop' 的文本时终止 bot。
-bot.processor<KMarkdownEventExtra> {
+bot.subscribe<KMarkdownEventExtra> {
     // raw 代表事件的原始JSON字符串
     // this: Event<KMarkdownEventExtra>, 也就是解析出来的事件结构体，
     // 并且 extra 类型为指定的 KMarkdownEventExtra
@@ -176,9 +176,9 @@ Bot bot = BotFactory.create(ticket, config -> {
     // 一些其他的配置...
 });
 
-// 通过 processor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理所有类型的事件
-bot.processor(EventProcessors.async((event, raw) -> {
+bot.subscribe(EventProcessors.async((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Event<*>, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -189,10 +189,10 @@ bot.processor(EventProcessors.async((event, raw) -> {
     return CompletableFuture.completedFuture(null);
 }));
 
-// 通过 processor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理指定的类型 AtMessageCreate 的事件
 // 此示例展示处理 AtMessageCreate 也就公域是消息事件，并在对方发送了包含 'stop' 的文本时终止 bot。
-bot.processor(EventProcessors.async(KMarkdownEventExtra.class, (event, raw) -> {
+bot.subscribe(EventProcessors.async(KMarkdownEventExtra.class, (event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Event<? extends KMarkdownEventExtra>, 也就是解析出来的事件结构体
     System.out.println("event kmarkdown: " + event.getExtra().getKmarkdown());
@@ -233,9 +233,9 @@ Bot bot = BotFactory.create(ticket, config -> {
     // 一些其他的配置...
 });
 
-// 通过 processor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理所有类型的事件
-bot.processor(EventProcessors.async((event, raw) -> {
+bot.subscribe(EventProcessors.async((event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Event<*>, 也就是解析出来的事件结构体
     System.out.println("event: " + event);
@@ -243,10 +243,10 @@ bot.processor(EventProcessors.async((event, raw) -> {
     System.out.println("raw: " + raw);
 }));
 
-// 通过 processor 注册一个普通的事件处理器，
+// 通过 subscribe 注册一个普通的事件处理器，
 // 此处理器会接收并处理指定的类型 AtMessageCreate 的事件
 // 此示例展示处理 AtMessageCreate 也就公域是消息事件，并在对方发送了包含 'stop' 的文本时终止 bot。
-    bot.processor(EventProcessors.block(KMarkdownEventExtra.class, (event, raw) -> {
+    bot.subscribe(EventProcessors.block(KMarkdownEventExtra.class, (event, raw) -> {
     // raw 代表事件的原始JSON字符串
     // event: Event<? extends KMarkdownEventExtra>, 也就是解析出来的事件结构体
     System.out.println("event kmarkdown: " + event.getExtra().getKmarkdown());

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotVerifyInfoConfiguration.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/KookBotVerifyInfoConfiguration.kt
@@ -27,7 +27,7 @@ import love.forte.simbot.component.kook.KookComponent
 import love.forte.simbot.component.kook.bot.KookBotVerifyInfoConfiguration.Ticket
 import love.forte.simbot.kook.TokenType
 import love.forte.simbot.kook.stdlib.BotConfiguration
-import love.forte.simbot.kook.stdlib.ProcessorType
+import love.forte.simbot.kook.stdlib.SubscribeSequence
 
 /**
  * `.bot` 配置文件读取的配置信息实体, 用于接收序列化配置信息。
@@ -160,7 +160,7 @@ public data class KookBotVerifyInfoConfiguration(
 
 
         /**
-         * [ProcessorType.NORMAL] 类型的事件处理器是否在异步中执行。
+         * [SubscribeSequence.NORMAL] 类型的事件处理器是否在异步中执行。
          *
          * 更多说明参考 [BotConfiguration.isNormalEventProcessAsync]
          *

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/bot/internal/KookBotEvents.kt
@@ -35,7 +35,7 @@ import love.forte.simbot.kook.DiscreetKookApi
 import love.forte.simbot.kook.api.user.GetUserViewApi
 import love.forte.simbot.kook.event.*
 import love.forte.simbot.kook.objects.SimpleUser
-import love.forte.simbot.kook.stdlib.ProcessorType
+import love.forte.simbot.kook.stdlib.SubscribeSequence
 import love.forte.simbot.kook.event.Event as KEvent
 import love.forte.simbot.kook.objects.User as KUser
 
@@ -71,7 +71,7 @@ internal fun KookBotImpl.registerEvent() {
     val thisBot = this
 
 
-    sourceBot.processor(ProcessorType.PREPARE) { rawEvent ->
+    sourceBot.subscribe(SubscribeSequence.PREPARE) { rawEvent ->
         val event = this
 
         when (val ex = extra) {
@@ -286,7 +286,7 @@ internal fun KookBotImpl.registerEvent() {
                             members.entries.removeAll { (k, _) -> k.guildId == guildId }
 
                             removedGuild
-                        } ?: return@processor
+                        } ?: return@subscribe
 
                         pushAndLaunch(
                             KookBotSelfExitedGuildEventImpl(
@@ -434,7 +434,11 @@ internal fun KookBotImpl.registerEvent() {
                                 }
 
                                 else -> {
-                                    logger.warn("No chat channel or category ({}) removed in event {}", ex.body.id, event)
+                                    logger.warn(
+                                        "No chat channel or category ({}) removed in event {}",
+                                        ex.body.id,
+                                        event
+                                    )
                                 }
                             }
                         }
@@ -603,7 +607,7 @@ private fun KookBotImpl.pushUnsupported(event: KEvent<EventExtra>, sourceEventJs
 }
 
 
-private inline fun KookBotImpl.pushAndLaunch(event: Event): Job {
+private fun KookBotImpl.pushAndLaunch(event: Event): Job {
     return launch {
         eventProcessor.push(event)
             .onEachError { er ->

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/BotConfiguration.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/BotConfiguration.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.kook.stdlib
@@ -210,10 +213,10 @@ public class BotConfiguration {
 
 
     /**
-     * [ProcessorType.NORMAL] 类型的事件处理器是否在异步中执行。
+     * [SubscribeSequence.NORMAL] 类型的事件处理器是否在异步中执行。
      * 默认为 `true`。
-     * 当为 `false` 时, [ProcessorType.NORMAL] 的表现效果将会与
-     * [ProcessorType.PREPARE] 基本类似。
+     * 当为 `false` 时, [SubscribeSequence.NORMAL] 的表现效果将会与
+     * [SubscribeSequence.PREPARE] 基本类似。
      */
     public var isNormalEventProcessAsync: Boolean = true
 

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/BotSubscribes.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/BotSubscribes.kt
@@ -1,0 +1,73 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     This file is part of simbot-component-kook.
+ *
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.kook.stdlib
+
+import love.forte.simbot.kook.event.Event
+import love.forte.simbot.kook.event.EventExtra
+
+
+/**
+ * 订阅一个具体的 [EventExtra] 类型的事件。
+ *
+ * ```kotlin
+ * bot.subscribe<E> { raw ->
+ *      // ...
+ * }
+ * ```
+ *
+ * @param subscribeSequence 事件处理器的序列类型，默认为 [SubscribeSequence.NORMAL]
+ * @param EX 事件内容 [Event.extra] 的具体类型。
+ */
+public inline fun <reified EX : EventExtra> Bot.subscribe(
+    subscribeSequence: SubscribeSequence = SubscribeSequence.NORMAL,
+    crossinline processor: suspend Event<EX>.(raw: String) -> Unit
+) {
+    subscribe(subscribeSequence) { raw ->
+        if (extra is EX) {
+            @Suppress("UNCHECKED_CAST")
+            processor.invoke(this as Event<EX>, raw)
+        }
+    }
+}
+
+/**
+ * 订阅一个 [Event.type] 目标的事件。
+ *
+ * ```kotlin
+ * bot.subscribe(type) { raw ->
+ *      // ...
+ * }
+ * ```
+ *
+ * @param type 事件类型
+ * @param subscribeSequence 事件处理器的序列类型，默认为 [SubscribeSequence.NORMAL]
+ */
+public inline fun Bot.subscribe(
+    type: Event.Type,
+    subscribeSequence: SubscribeSequence = SubscribeSequence.NORMAL,
+    crossinline processor: suspend Event<*>.(raw: String) -> Unit
+) {
+    subscribe(subscribeSequence) { raw ->
+        if (this.type == type) {
+            processor(raw)
+        }
+    }
+}

--- a/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/internal/BotImpl.kt
+++ b/simbot-component-kook-stdlib/src/commonMain/kotlin/love/forte/simbot/kook/stdlib/internal/BotImpl.kt
@@ -59,12 +59,12 @@ internal class BotImpl(
 
     internal val authorization: String = "${ticket.type.prefix} ${ticket.token}"
 
-    private val queueMap = ActualEnumMap.create<ProcessorType, ConcurrentQueue<EventProcessor>> {
+    private val queueMap = ActualEnumMap.create<SubscribeSequence, ConcurrentQueue<EventProcessor>> {
         createConcurrentQueue()
     }
 
-    override fun processor(processorType: ProcessorType, processor: EventProcessor) {
-        queueMap[processorType].add(processor)
+    override fun subscribe(subscribeSequence: SubscribeSequence, processor: EventProcessor) {
+        queueMap[subscribeSequence].add(processor)
     }
 
     private val job = SupervisorJob(configuration.coroutineContext[Job])
@@ -247,8 +247,8 @@ internal class BotImpl(
     }
 
     internal suspend fun processEvent(event: Signal.Event<*>, raw: String) {
-        val prepareProcessors = queueMap[ProcessorType.PREPARE]
-        val normalProcessors = queueMap[ProcessorType.NORMAL]
+        val prepareProcessors = queueMap[SubscribeSequence.PREPARE]
+        val normalProcessors = queueMap[SubscribeSequence.NORMAL]
         if (prepareProcessors.size == 0 && normalProcessors.size == 0) {
             eventLogger.trace("prepare processors and normal processors are both empty, skip.")
             return


### PR DESCRIPTION
这样更符合语义。废弃API保留二进制兼容一段时间。