### PR TITLE
支持KookQuote的获取和MessageReference的解析

### DIFF
--- a/internal-processors/message-element-processor/build.gradle.kts
+++ b/internal-processors/message-element-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2022-2024. ForteScarlet.
+ *     Copyright (c) 2024. ForteScarlet.
  *
  *     This file is part of simbot-component-kook.
  *
@@ -18,14 +18,33 @@
  *     If not, see <https://www.gnu.org/licenses/>.
  */
 
-rootProject.name = "simbot-component-kook"
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-// internals
-include(":internal-processors:api-reader")
-include(":internal-processors:message-element-processor")
+plugins {
+    kotlin("jvm")
+}
 
-include("simbot-component-kook-api")
-include("simbot-component-kook-stdlib")
-include("simbot-component-kook-core")
+repositories {
+    mavenCentral()
+}
 
-//include("simbot-component-kook-stdlib-test")
+kotlin {
+    jvmToolchain(11)
+    compilerOptions {
+        javaParameters = true
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
+
+configJavaCompileWithModule()
+
+dependencies {
+    api(libs.ksp)
+    api(libs.kotlinPoet.ksp)
+    testImplementation(kotlin("test-junit5"))
+}
+
+tasks.getByName<Test>("test") {
+    useJUnitPlatform()
+}
+

--- a/internal-processors/message-element-processor/src/main/kotlin/kook/internal/processors/msgelement/MessageElementProcessor.kt
+++ b/internal-processors/message-element-processor/src/main/kotlin/kook/internal/processors/msgelement/MessageElementProcessor.kt
@@ -1,0 +1,148 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     This file is part of simbot-component-kook.
+ *
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package kook.internal.processors.msgelement
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.isAbstract
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import java.time.Instant
+import java.time.ZoneOffset
+
+
+private const val BASE_ELEMENT_CLASS_PACKAGE = "love.forte.simbot.component.kook.message"
+private const val BASE_ELEMENT_CLASS_SIMPLE_NAME = "KookMessageElement"
+
+private const val BASE_ELEMENT_CLASS_NAME =
+    "$BASE_ELEMENT_CLASS_PACKAGE.$BASE_ELEMENT_CLASS_SIMPLE_NAME"
+
+private val BaseElementClassName =
+    ClassName(BASE_ELEMENT_CLASS_PACKAGE, BASE_ELEMENT_CLASS_SIMPLE_NAME)
+
+private const val KTX_SERIALIZABLE_ANNOTATION_PACKAGE = "kotlinx.serialization"
+private const val KTX_SERIALIZABLE_ANNOTATION_SIMPLE_NAME = "Serializable"
+private const val KTX_SERIALIZABLE_ANNOTATION_NAME =
+    "$KTX_SERIALIZABLE_ANNOTATION_PACKAGE.$KTX_SERIALIZABLE_ANNOTATION_SIMPLE_NAME"
+
+private val PolymorphicModuleBuilderClassName =
+    ClassName("kotlinx.serialization.modules", "PolymorphicModuleBuilder")
+
+private const val OUTPUT_PACKAGE = "love.forte.simbot.component.kook.message"
+private const val OUTPUT_FILE = "IncludeKookMessageElements.generated"
+private const val OUTPUT_FUN_NAME = "includeKookMessageElements"
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class MessageElementProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor {
+    private val codeGenerator = environment.codeGenerator
+    private val elementDeclarations = mutableListOf<KSClassDeclaration>()
+
+    override fun finish() {
+        val newFun = resolve(elementDeclarations)
+
+        val fileSpec = FileSpec.Companion.builder(
+            OUTPUT_PACKAGE, OUTPUT_FILE
+        )
+            .addFunction(newFun)
+            .addFileComment("\nAuto-Generated at ${Instant.now().atOffset(ZoneOffset.ofHours(8))}\n")
+            .build()
+
+        fileSpec.writeTo(
+            codeGenerator = codeGenerator,
+            aggregating = true,
+            originatingKSFiles = buildList {
+                for (impl in elementDeclarations) {
+                    impl.containingFile?.also { add(it) }
+                }
+            }
+        )
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val baseClass = resolver.getClassDeclarationByName(
+            BASE_ELEMENT_CLASS_NAME
+        ) ?: error("Base class $BASE_ELEMENT_CLASS_NAME not found")
+
+        val baseClassStarType = baseClass.asStarProjectedType()
+
+        resolver
+            .getSymbolsWithAnnotation(KTX_SERIALIZABLE_ANNOTATION_NAME)
+            .filterIsInstance<KSClassDeclaration>()
+            .filter { declaration ->
+                // 是 base class 的子类
+                baseClassStarType.isAssignableFrom(declaration.asStarProjectedType())
+            }
+            .filter { declaration ->
+                // 不是抽象的、不是sealed的可序列化类
+                !declaration.isAbstract() && !declaration.modifiers.contains(Modifier.SEALED)
+            }
+            .toCollection(elementDeclarations)
+
+        return emptyList()
+    }
+
+    /**
+     * 生成函数：
+     *
+     * ```kotlin
+     * internal fun PolymorphicModuleBuilder<KookMessageElement>.includeKookMessageElements() {
+     *      subclass(KookAsset::class, KookAsset.serializer())
+     *      // ...
+     * }
+     * ```
+     */
+    private fun resolve(declarations: List<KSClassDeclaration>): FunSpec {
+        val receiverType = PolymorphicModuleBuilderClassName.parameterizedBy(BaseElementClassName)
+//        val optAnnotation =
+        val optAnnotation = AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
+            .addMember(
+                "%T::class, %T::class",
+                ClassName("love.forte.simbot.annotations", "ExperimentalSimbotAPI"),
+                ClassName("love.forte.simbot.kook", "ExperimentalKookApi")
+            )
+            .build()
+
+        val internalAPIAnnotation = ClassName("love.forte.simbot.kook", "InternalKookApi")
+
+        return FunSpec.builder(OUTPUT_FUN_NAME).apply {
+            modifiers.add(KModifier.INTERNAL)
+            receiver(receiverType)
+            addAnnotation(optAnnotation)
+            addAnnotation(internalAPIAnnotation)
+
+            for (declaration in declarations) {
+                val className = declaration.toClassName()
+                addCode("subclass(%T::class, %T.serializer())\n", className, className)
+            }
+        }.build()
+    }
+}
+

--- a/internal-processors/message-element-processor/src/main/kotlin/kook/internal/processors/msgelement/MessageElementProcessorProvider.kt
+++ b/internal-processors/message-element-processor/src/main/kotlin/kook/internal/processors/msgelement/MessageElementProcessorProvider.kt
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2022-2024. ForteScarlet.
+ *     Copyright (c) 2024. ForteScarlet.
  *
  *     This file is part of simbot-component-kook.
  *
@@ -18,14 +18,18 @@
  *     If not, see <https://www.gnu.org/licenses/>.
  */
 
-rootProject.name = "simbot-component-kook"
+package kook.internal.processors.msgelement
 
-// internals
-include(":internal-processors:api-reader")
-include(":internal-processors:message-element-processor")
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
-include("simbot-component-kook-api")
-include("simbot-component-kook-stdlib")
-include("simbot-component-kook-core")
+/**
+ *
+ * @author ForteScarlet
+ */
+class MessageElementProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        MessageElementProcessor(environment)
+}
 
-//include("simbot-component-kook-stdlib-test")

--- a/internal-processors/message-element-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/internal-processors/message-element-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+kook.internal.processors.msgelement.MessageElementProcessorProvider

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/Kook.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/Kook.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.kook
@@ -82,6 +85,7 @@ public object Kook {
         useArrayPolymorphism = false
         // see https://github.com/kaiheila/api-docs/issues/174
         explicitNulls = false
+        coerceInputValues = true
     }
 }
 

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/messages/MessageDetails.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/messages/MessageDetails.kt
@@ -1,24 +1,30 @@
 /*
- * Copyright (c) 2021-2023. ForteScarlet.
+ *     Copyright (c) 2021-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.kook.messages
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import love.forte.simbot.kook.Kook
 import love.forte.simbot.kook.api.ApiResultType
 import love.forte.simbot.kook.objects.*
 
@@ -168,16 +174,33 @@ public data class ChannelMessageDetails(
  */
 @Serializable
 public data class DirectMessageDetails(
-    override val id: String,
-    override val type: Int,
-    @SerialName("author_id") override val authorId: String,
-    override val content: String,
-    override val embeds: List<Map<String, String>> = emptyList(),
-    override val attachments: Attachments? = null,
-    override val reactions: List<Reaction> = emptyList(),
-    override val quote: Quote? = null,
+    public val id: String,
+    public val type: Int,
+    @SerialName("author_id") public val authorId: String,
+    public val content: String,
+    public val embeds: List<Map<String, String>> = emptyList(),
+    // 2024/8/6
+    // 事件中，客户端发送的附件都被转成了card消息，attachments 永远为 null，看不出结构；
+    // 私聊事件查询详情时会得到空数组 `"attachments":[]`, 进而导致报错
+    // 暂时不知道到底是两边都是数组，还是只有私聊变成了数组，因此暂且仅处理私聊。
+    @SerialName("attachments")
+    public val attachmentsList: List<SimpleAttachments>? = null,
+    public val reactions: List<Reaction> = emptyList(),
+    // 如果没有引用，会冒出来一个空字符串。
+    // 我真服了。
+    @SerialName("quote")
+    private val sourceQuote: JsonElement? = null,
     @SerialName("read_status") public val readStatus: Boolean = false,
-) : MessageDetails
+) {
+    val quote: Quote?
+        get() {
+            val obj = (sourceQuote as? JsonObject?) ?: return null
+            return Kook.DEFAULT_JSON.decodeFromJsonElement(Quote.serializer(), obj)
+        }
+
+    public val attachments: Attachments?
+        get() = attachmentsList?.firstOrNull()
+}
 
 
 /**

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/objects/Attachments.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/objects/Attachments.kt
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ *     Copyright (c) 2023-2024. ForteScarlet.
  *
- * This file is part of simbot-component-kook.
+ *     This file is part of simbot-component-kook.
  *
- * simbot-component-kook is free software: you can redistribute it and/or modify it under the terms of
- * the GNU Lesser General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
  *
- * simbot-component-kook is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along with simbot-component-kook,
- * If not, see <https://www.gnu.org/licenses/>.
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
  */
 
 package love.forte.simbot.kook.objects
@@ -59,9 +62,9 @@ public interface Attachments {
  */
 @Serializable
 public data class SimpleAttachments(
-    override val type: String,
-    override val url: String,
-    override val name: String,
+    override val type: String = "",
+    override val url: String = "",
+    override val name: String = "",
     override val size: Long = -1
 ) : Attachments
 

--- a/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/objects/card/Card.kt
+++ b/simbot-component-kook-api/src/commonMain/kotlin/love/forte/simbot/kook/objects/card/Card.kt
@@ -119,6 +119,7 @@ public data class CardMessage(private val cards: List<Card>) : List<Card> by car
             isLenient = true
             ignoreUnknownKeys = true
             encodeDefaults = true
+            coerceInputValues = true
         }
 
         /**

--- a/simbot-component-kook-core/build.gradle.kts
+++ b/simbot-component-kook-core/build.gradle.kts
@@ -18,6 +18,7 @@
  *     If not, see <https://www.gnu.org/licenses/>.
  */
 
+import com.google.devtools.ksp.gradle.KspTaskMetadata
 import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
@@ -82,13 +83,11 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            runtimeOnly(libs.ktor.client.cio)
-//            runtimeOnly(libs.kotlinx.coroutines.reactor)
-//            implementation(libs.reactor.core)
+            implementation(libs.ktor.client.java)
 
-            implementation(libs.log4j.api)
-            implementation(libs.log4j.core)
-            implementation(libs.log4j.slf4j2Impl)
+            implementation(libs.simbot.logger.slf4jimpl)
+//            implementation(libs.log4j.core)
+//            implementation(libs.log4j.slf4j2Impl)
         }
 
         jsMain.dependencies {
@@ -109,6 +108,7 @@ kotlin {
 
 dependencies {
     add("kspJvm", project(":internal-processors:api-reader"))
+    add("kspCommonMainMetadata", project(":internal-processors:message-element-processor"))
 }
 
 ksp {
@@ -117,3 +117,11 @@ ksp {
     arg("kook.api.finder.event.output", rootDir.resolve("generated-docs/core-event-list.md").absolutePath)
     arg("kook.api.finder.event.class", "love.forte.simbot.component.kook.event.KookEvent")
 }
+
+ kotlin.sourceSets.commonMain {
+     // solves all implicit dependency trouble and IDEs source code detection
+     // see https://github.com/google/ksp/issues/963#issuecomment-1894144639
+     tasks.withType<KspTaskMetadata> {
+         kotlin.srcDir(destinationDirectory.file("kotlin"))
+     }
+ }

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/KookComponent.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/KookComponent.kt
@@ -21,11 +21,9 @@
 package love.forte.simbot.component.kook
 
 
-import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import love.forte.simbot.annotations.ExperimentalSimbotAPI
 import love.forte.simbot.bot.serializableBotConfigurationPolymorphic
 import love.forte.simbot.common.function.ConfigurerFunction
 import love.forte.simbot.common.function.invokeBy
@@ -34,11 +32,12 @@ import love.forte.simbot.component.ComponentConfigureContext
 import love.forte.simbot.component.ComponentFactory
 import love.forte.simbot.component.ComponentFactoryProvider
 import love.forte.simbot.component.kook.bot.KookBotVerifyInfoConfiguration
-import love.forte.simbot.component.kook.message.*
+import love.forte.simbot.component.kook.message.KookMessageElement
+import love.forte.simbot.component.kook.message.includeKookMessageElements
 import love.forte.simbot.kook.ExperimentalKookApi
 import love.forte.simbot.kook.objects.kmd.KMarkdown
 import love.forte.simbot.kook.objects.kmd.RawValueKMarkdown
-import love.forte.simbot.message.Message
+import love.forte.simbot.message.messageElementPolymorphic
 import kotlin.jvm.JvmStatic
 
 /**
@@ -104,36 +103,19 @@ public class KookComponent : Component {
         /**
          * [KookComponent] 组件所使用的消息序列化信息。
          */
-        @OptIn(ExperimentalSimbotAPI::class, ExperimentalKookApi::class)
+        @OptIn(ExperimentalKookApi::class)
         @get:JvmStatic
         public val messageSerializersModule: SerializersModule = SerializersModule {
-            fun PolymorphicModuleBuilder<KookMessageElement>.include() {
-                subclass(KookAsset::class, KookAsset.serializer())
-                subclass(KookAssetImage::class, KookAssetImage.serializer())
-                subclass(KookAtAllHere::class, KookAtAllHere.serializer())
-                // KookAttachmentMessage
-                subclass(KookAttachment::class, KookAttachment.serializer())
-                subclass(KookAttachmentImage::class, KookAttachmentImage.serializer())
-                subclass(KookAttachmentFile::class, KookAttachmentFile.serializer())
-                subclass(KookAttachmentVideo::class, KookAttachmentVideo.serializer())
+            polymorphic(KookMessageElement::class) {
+                includeKookMessageElements()
+            }
 
-                subclass(KookCardMessage::class, KookCardMessage.serializer())
-                subclass(KookKMarkdownMessage::class, KookKMarkdownMessage.serializer())
-
-                subclass(KookTempTarget.Current::class, KookTempTarget.Current.serializer())
-                subclass(KookTempTarget.Target::class, KookTempTarget.Target.serializer())
+            messageElementPolymorphic {
+                includeKookMessageElements()
             }
 
             polymorphic(KMarkdown::class) {
                 subclass(RawValueKMarkdown::class, RawValueKMarkdown.serializer())
-            }
-
-            polymorphic(KookMessageElement::class) {
-                include()
-            }
-
-            polymorphic(Message.Element::class) {
-                include()
             }
 
             serializableBotConfigurationPolymorphic {

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/event/KookUpdatedMessageEvent.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/event/KookUpdatedMessageEvent.kt
@@ -111,6 +111,7 @@ public abstract class KookUpdatedChannelMessageEvent : KookUpdatedMessageEvent()
         KookUpdatedMessageContent(
             bot = bot,
             isDirect = false,
+            chatCode = null,
             rawContent = sourceBody.content,
             msgId = sourceBody.msgId,
             mention = sourceBody.mention,
@@ -178,6 +179,7 @@ public abstract class KookUpdatedPrivateMessageEvent : KookUpdatedMessageEvent()
         KookUpdatedMessageContent(
             bot = bot,
             isDirect = true,
+            chatCode = sourceBody.chatCode,
             rawContent = sourceBody.content,
             msgId = sourceBody.msgId,
             mention = emptyList(),

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/message/KookChannelMessageDetailsContent.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/message/KookChannelMessageDetailsContent.kt
@@ -31,6 +31,8 @@ import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.kook.bot.KookBot
 import love.forte.simbot.component.kook.message.KookAttachmentMessage.Companion.asMessage
+import love.forte.simbot.component.kook.message.KookQuote.Companion.asMessage
+import love.forte.simbot.component.kook.util.requestDataBy
 import love.forte.simbot.component.kook.util.requestResultBy
 import love.forte.simbot.kook.api.ApiResponseException
 import love.forte.simbot.kook.api.message.DeleteChannelMessageApi
@@ -43,6 +45,7 @@ import love.forte.simbot.message.Messages
 import love.forte.simbot.message.PlainText
 import love.forte.simbot.message.toText
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 /**
  * 将 [ChannelMessageDetails] 作为消息正文实现。
@@ -51,7 +54,7 @@ import kotlin.jvm.JvmStatic
  * @see GetChannelMessageViewApi
  * @author ForteScarlet
  */
-public data class KookChannelMessageDetailsContent(
+public data class KookChannelMessageDetailsContent internal constructor(
     internal val details: ChannelMessageDetails,
     private val bot: KookBot,
 ) : KookMessageContent {
@@ -89,6 +92,12 @@ public data class KookChannelMessageDetailsContent(
      */
     override val plainText: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
         messages.filterIsInstance<PlainText>().joinToString("") { it.text }
+    }
+
+    @JvmSynthetic
+    override suspend fun reference(): KookQuote? {
+        val details = GetChannelMessageViewApi.create(details.id).requestDataBy(bot)
+        return details.quote?.asMessage()
     }
 
     /**

--- a/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/message/KookQuote.kt
+++ b/simbot-component-kook-core/src/commonMain/kotlin/love/forte/simbot/component/kook/message/KookQuote.kt
@@ -1,0 +1,58 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     This file is part of simbot-component-kook.
+ *
+ *     simbot-component-kook is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     simbot-component-kook is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with simbot-component-kook,
+ *     If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.kook.message
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.StringID.Companion.ID
+import love.forte.simbot.kook.objects.Quote
+import love.forte.simbot.message.MessageIdReference
+import love.forte.simbot.message.MessageReference
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
+
+
+/**
+ * 一个通过 [KookMessageContent.reference]
+ * 查询得到的消息引用信息。
+ *
+ * 也可用于发送，效果等同于使用 [MessageIdReference]。
+ *
+ * @author ForteScarlet
+ */
+@SerialName("kook.quote")
+@Serializable
+public data class KookQuote internal constructor(public val quote: Quote) :
+    MessageReference {
+    override val id: ID
+        get() = quote.id.ID
+
+    public companion object {
+        /**
+         * 将 [Quote] 作为 [KookQuote]。
+         */
+        @JvmStatic
+        @JvmName("create")
+        public fun Quote.asMessage(): KookQuote = KookQuote(this)
+    }
+
+}


### PR DESCRIPTION
- 支持通过 `KookMessageContent.reference()` 获取 `KookQuote`
- 支持直接使用 `MessageReference` 指定一个消息引用（也包括 `KookQuote`）

resolve https://github.com/simple-robot/simbot-component-kook/issues/156

see also https://github.com/simple-robot/simpler-robot/issues/898

顺便发现了几个KOOK服务端的 **狗*** 问题：

**attrchements**

- 文字子频道消息似乎收到的 `attrchements` 永远为 `null` 进而无法判断它到底是什么结构的，虽然文档上说是个 object 结构。
- 而私聊会话中，`attrchemenets` 在没有任何多媒体消息的情况下给的是空数组结构 `[]`，与文档描述相悖。

**quote**

私聊会话中，一个消息如果不包括引用，则查询details中 `quote` 字符响应的竟然是个空字符串：

```json
{"quote":""}
```

而实际包含引用的情况下，返回的又是普通的 `Quote` 结构体：

```json5
{"quote":{"id":"..."}}
```

...

...

我服了。

